### PR TITLE
Add additional Tuple2 & Tuple3 functions from ‘extras’

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install via npm by:
 
 Then add to your bsconfig.json file:
 
-`  "bs-dependencies" : ["tablecloth-bucklescript"]`
+`"bs-dependencies" : ["tablecloth-bucklescript"]`
 
 ### OCaml native
 
@@ -27,17 +27,18 @@ Install via opam:
 
 Then add to your dune file:
 
-`  (libraries (tablecloth-native ...))`
+`(libraries (tablecloth-native ...))`
 
 ### js_of_ocaml
 
-We have not built a js\_of\_ocaml specific version yet. However, the native version should work perfectly with js\_of\_ocaml.
+We have not built a js_of_ocaml specific version yet. However, the native version should work perfectly with js_of_ocaml.
 
 ## Usage
 
 By design, the usage of the libraries is the same on all platforms:
 
 Either open the module, and replace the builtin modules
+
 ```
 open Tablecloth
 
@@ -51,6 +52,7 @@ let () =
 ```
 
 Or use the fully qualified names:
+
 ```
 let () =
   "somestring"
@@ -67,25 +69,26 @@ upstreaming them. We have [an
 example](https://github.com/darklang/tablecloth/blob/master/examples/tc.ml)
 that you can copy from.
 
-
 ## Design of Tablecloth
 
 [Dark](https://darklang.com) uses multiple versions of OCaml on the frontend
 and backend:
+
 - Our backend is written in OCaml native, using [Jane Street Core](https://github.com/janestreet/core) as a standard
   library
 - Our frontend is written in [Bucklescript](https://bucklescript.github.io/) (dba [ReasonML](https://reasonml.github.io/))
 - Parts of our backend are shared with the frontend by compiling them using
-  js\_of\_ocaml, and running them in a web worker.
+  js_of_ocaml, and running them in a web worker.
 
 We discovered that it was impossible to share code between the Bucklescript
 frontend and the OCaml backend, as the types and standard libraries were very
 different:
+
 - Bucklescript uses camelCase by default, while most native libraries,
-  including Core and the OCaml standard library, use snake\_case.
+  including Core and the OCaml standard library, use snake_case.
 - The libraries in [Belt](https://bucklescript.github.io/bucklescript/api/index.html) have different names and function signatures than native OCaml and Base/Core.
 - Many OCaml libraries have APIs optimized for pipelast (`|>`), while Belt aims
-  for pipefirst (`|.`). 
+  for pipefirst (`|.`).
 - Core does not work with Bucklescript, while Belt is optimized for the JS
   platform.
 - Belt does not work in native OCaml, while Core is optimized for the native
@@ -94,7 +97,6 @@ different:
   libraries (such as [Elm's](https://package.elm-lang.org/packages/elm/core/1.0.2/)).
 - Belt makes it challenging to use [PPXes](https://github.com/ocaml-ppx).
 
-
 ### Tablecloth's solution
 
 Tablecloth solves this by providing an identical API for Bucklescript and
@@ -102,26 +104,27 @@ OCaml. It wraps existing standard libraries on those platforms, and so is fast
 and memory efficient. It is based off Elm standard library, which is extremely
 well-designed and ergonomic.
 
-Tablecloth provides separate libraries for OCaml native, js\_of\_ocaml, and
+Tablecloth provides separate libraries for OCaml native, js_of_ocaml, and
 Bucklescript. The libraries have the same API, but different implementations,
 and are installed as different packages.
 
 The APIs:
+
 - are taken from [Elm's standard library](https://package.elm-lang.org/packages/elm/core/1.0.2/), which is extremely complete and well-designed.
 - include support for strings, lists, numbers, maps, options, and results,
-- have both snake\_case and camelCase versions of all functions and types,
+- have both snake_case and camelCase versions of all functions and types,
 - are backed by [Jane Street Base](https://opensource.janestreet.com/base/) for native OCaml
 - are backed by Belt and the `Js` library for Bucklescript/ReasonML,
 - use labelled arguments so that can be used with both pipefirst and pipelast,
 
 We also have design goals that are not yet achieved in the current version:
+
 - Many of the functions in the Bucklescript version were written hastily, and could be much more efficient
 - Tablecloth libraries should support PPX derivers,
 - Tablecloth functions should not throw any exceptions,
 - All functions should be well documented, with well-known and consistent edge-case behaviour,
 - All functions should be well tested,
 - There should have a js_of_ocaml optimized version (and perhaps a version wrapping other OCaml standard libraries like [Batteries](https://github.com/ocaml-batteries-team/batteries-included) or [Containers](https://github.com/c-cube/ocaml-containers)).
-
 
 ## Contributing
 
@@ -132,6 +135,7 @@ small tasks to be done - a small change to a single function can be extremely
 helpful.
 
 Here are some ways to contribute:
+
 - point out inconsistencies between different functions in the library,
 - point out an inelegant function signature which could be improved,
 - point out a way in which the library or any of its parts are confusing,
@@ -151,10 +155,9 @@ Here are some ways to contribute:
 - design escape hatches, where the user could convert a `t` into a
   platform-specific type, to allow them create functions we do not currently
   support,
-- add a js\_of\_ocaml-optimized version,
+- add a js_of_ocaml-optimized version,
 - add a Caml namespace to allow users to access the builtin OCaml library
   functions
-- add a Tuple3 module
 - add more functions from any of Elm's core library: String, List, Result,
   Maybe, Array, Dict, Set, Tuple, or Basics, or from any of the Extras
   libraries.
@@ -175,4 +178,3 @@ license.
 ## Authors
 
 Written by [Dark](https://darklang.com). We may be [hiring](https://darklang.com/careers).
-

--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -21,6 +21,10 @@ let () =
       expect (Tuple2.second (3, 4)) |> toEqual 4      
     );
 
+    test "map" (fun () ->
+      expect (Tuple2.map ~f:sqrt ("stressed", 16.)) |> toEqual ("stressed", 4.)      
+    );
+
     test "mapFirst" (fun () ->
       expect (Tuple2.mapFirst ~f:String.reverse ("stressed", 16)) |> toEqual ("desserts", 16)      
     );
@@ -29,9 +33,21 @@ let () =
       expect (Tuple2.mapSecond ~f:sqrt ("stressed", 16.)) |> toEqual ("stressed", 4.)      
     );
 
-    test "mapBoth" (fun () ->
-      expect (Tuple2.mapBoth ~f:String.reverse ~g:sqrt ("stressed", 16.)) |> toEqual ("desserts", 4.)      
-    )
+    test "mapEach" (fun () ->
+      expect (Tuple2.mapEach ~f:String.reverse ~g:sqrt ("stressed", 16.)) |> toEqual ("desserts", 4.)      
+    );
+
+    test "mapAll" (fun () ->
+      expect (Tuple2.mapAll ~f:String.reverse ("was", "stressed")) |> toEqual ("saw", "desserts")      
+    );
+
+    test "swap" (fun () ->
+      expect (Tuple2.swap (3, 4)) |> toEqual (4, 3)      
+    );
+
+    test "toList" (fun () ->
+      expect (Tuple2.toList (3, 4)) |> toEqual [3; 4]
+    );
   );
 
   describe "Tuple3" (fun () ->
@@ -51,6 +67,18 @@ let () =
       expect (Tuple3.third (3, 4, 5)) |> toEqual 5      
     );
 
+    test "head" (fun () -> 
+      expect (Tuple3.head (3, 4, 5)) |> toEqual (3, 4)      
+    );
+
+    test "tail" (fun () -> 
+      expect (Tuple3.tail (3, 4, 5)) |> toEqual (4, 5)      
+    );
+
+    test "map" (fun () ->
+      expect (Tuple3.map ~f:not ("stressed", 16, false)) |> toEqual ("stressed", 16, true);
+    );
+
     test "mapFirst" (fun () ->
       expect (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) |> toEqual ("desserts", 16, false)
     );
@@ -66,6 +94,20 @@ let () =
     test "mapEach" (fun () ->
       expect (Tuple3.mapEach ~f:String.reverse ~g:sqrt ~h:not ("stressed", 16., false)) |> toEqual ("desserts", 4., true)
     );
-  );
 
-  ()
+    test "mapAll" (fun () ->
+      expect (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) |> toEqual ("saw", "desserts", "won")
+    );
+
+    test "swirlLeft" (fun () ->
+      expect (Tuple3.swirlLeft (3, 4, 5)) |> toEqual (5, 3, 4)
+    );
+
+    test "swirlRight" (fun () ->
+      expect (Tuple3.swirlRight (3, 4, 5)) |> toEqual (4, 5, 3)
+    );
+
+    test "toList" (fun () ->
+      expect (Tuple3.toList (3, 4, 5)) |> toEqual [3; 4; 5]
+    );
+  );

--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -99,12 +99,12 @@ let () =
       expect (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) |> toEqual ("saw", "desserts", "won")
     );
 
-    test "swirlLeft" (fun () ->
-      expect (Tuple3.swirlLeft (3, 4, 5)) |> toEqual (5, 3, 4)
+    test "rotateLeft" (fun () ->
+      expect (Tuple3.rotateLeft (3, 4, 5)) |> toEqual (5, 3, 4)
     );
 
-    test "swirlRight" (fun () ->
-      expect (Tuple3.swirlRight (3, 4, 5)) |> toEqual (4, 5, 3)
+    test "rotateRight" (fun () ->
+      expect (Tuple3.rotateRight (3, 4, 5)) |> toEqual (4, 5, 3)
     );
 
     test "toList" (fun () ->

--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -67,8 +67,8 @@ let () =
       expect (Tuple3.third (3, 4, 5)) |> toEqual 5      
     );
 
-    test "head" (fun () -> 
-      expect (Tuple3.head (3, 4, 5)) |> toEqual (3, 4)      
+    test "init" (fun () -> 
+      expect (Tuple3.init (3, 4, 5)) |> toEqual (3, 4)      
     );
 
     test "tail" (fun () -> 

--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -21,10 +21,6 @@ let () =
       expect (Tuple2.second (3, 4)) |> toEqual 4      
     );
 
-    test "map" (fun () ->
-      expect (Tuple2.map ~f:sqrt ("stressed", 16.)) |> toEqual ("stressed", 4.)      
-    );
-
     test "mapFirst" (fun () ->
       expect (Tuple2.mapFirst ~f:String.reverse ("stressed", 16)) |> toEqual ("desserts", 16)      
     );
@@ -75,10 +71,6 @@ let () =
       expect (Tuple3.tail (3, 4, 5)) |> toEqual (4, 5)      
     );
 
-    test "map" (fun () ->
-      expect (Tuple3.map ~f:not ("stressed", 16, false)) |> toEqual ("stressed", 16, true);
-    );
-
     test "mapFirst" (fun () ->
       expect (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) |> toEqual ("desserts", 16, false)
     );
@@ -100,11 +92,11 @@ let () =
     );
 
     test "rotateLeft" (fun () ->
-      expect (Tuple3.rotateLeft (3, 4, 5)) |> toEqual (5, 3, 4)
+      expect (Tuple3.rotateLeft (3, 4, 5)) |> toEqual (4, 5, 3)
     );
 
     test "rotateRight" (fun () ->
-      expect (Tuple3.rotateRight (3, 4, 5)) |> toEqual (4, 5, 3)
+      expect (Tuple3.rotateRight (3, 4, 5)) |> toEqual (5, 3, 4)
     );
 
     test "toList" (fun () ->

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -466,7 +466,7 @@ module Tuple3 = struct
   
   let third ((_, _, c) : 'a * 'b * 'c) : 'c = c
 
-  let head ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
+  let init ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
 
   let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -432,17 +432,29 @@ module Tuple2 = struct
   
   let second ((_, b) : 'a * 'b) : 'b = b
 
+  let map ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
+
   let mapFirst ~(f : 'a -> 'x) ((a, b) : 'a * 'b) : 'x * 'b = (f a, b)
 
   let map_first = mapFirst
 
-  let mapSecond ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
+  let mapSecond = map
 
   let map_second = mapSecond
 
-  let mapBoth ~(f : 'a -> 'x) ~(g : 'b -> 'y) ((a, b) : 'a * 'b) : 'x * 'y = (f a, g b)
+  let mapEach ~(f : 'a -> 'x) ~(g : 'b -> 'y) ((a, b) : 'a * 'b) : 'x * 'y = (f a, g b)
 
-  let map_both = mapBoth
+  let map_each = mapEach
+  
+  let mapAll ~(f : 'a -> 'b) (a1, a2) = (f a1, f a2)
+
+  let map_all = mapAll
+
+  let swap (a, b) = (b, a)
+
+  let toList (a, b) = [a; b]
+
+  let to_list = toList
 end
 
 module Tuple3 = struct
@@ -450,9 +462,15 @@ module Tuple3 = struct
 
   let first ((a, _, _) : 'a * 'b * 'c) : 'a = a
 
-  let second ((_, b, _) : 'a * 'b *'c) : 'b = b
+  let second ((_, b, _) : 'a * 'b * 'c) : 'b = b
   
   let third ((_, _, c) : 'a * 'b * 'c) : 'c = c
+
+  let head ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
+
+  let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
+
+  let map ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
 
   let mapFirst ~(f : 'a -> 'x) ((a, b, c) : 'a * 'b * 'c) : 'x * 'b *'c = (f a, b, c)
 
@@ -462,13 +480,29 @@ module Tuple3 = struct
 
   let map_second = mapSecond
 
-  let mapThird ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
+  let mapThird = map
 
   let map_third = mapThird
 
   let mapEach ~(f : 'a -> 'x) ~(g : 'b -> 'y) ~(h : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'x * 'y * 'z = (f a, g b, h c)
 
-  let map_each  = mapEach
+  let map_each = mapEach
+
+  let mapAll ~(f: 'a -> 'b) (a1, a2, a3) = (f a1, f a2, f a3)
+
+  let map_all = mapAll
+
+  let swirlLeft ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
+
+  let swirl_left = swirlLeft
+
+  let swirlRight ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
+
+  let swirl_right = swirlRight
+
+  let toList ((a, b, c) : ('a * 'a * 'a)) : 'a list = [a; b; c]
+
+  let to_list = toList
 end
 
 module String = struct

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -432,13 +432,11 @@ module Tuple2 = struct
   
   let second ((_, b) : 'a * 'b) : 'b = b
 
-  let map ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
-
   let mapFirst ~(f : 'a -> 'x) ((a, b) : 'a * 'b) : 'x * 'b = (f a, b)
 
   let map_first = mapFirst
 
-  let mapSecond = map
+  let mapSecond ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
 
   let map_second = mapSecond
 
@@ -470,8 +468,6 @@ module Tuple3 = struct
 
   let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
 
-  let map ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
-
   let mapFirst ~(f : 'a -> 'x) ((a, b, c) : 'a * 'b * 'c) : 'x * 'b *'c = (f a, b, c)
 
   let map_first = mapFirst
@@ -480,7 +476,7 @@ module Tuple3 = struct
 
   let map_second = mapSecond
 
-  let mapThird = map
+  let mapThird ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
 
   let map_third = mapThird
 
@@ -496,7 +492,7 @@ module Tuple3 = struct
 
   let rotate_left = rotateLeft
 
-  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'b * 'a) = (c, b, a)
+  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
 
   let rotate_right = rotateRight
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -492,13 +492,13 @@ module Tuple3 = struct
 
   let map_all = mapAll
 
-  let swirlLeft ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
+  let rotateLeft ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
 
-  let swirl_left = swirlLeft
+  let rotate_left = rotateLeft
 
-  let swirlRight ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
+  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'b * 'a) = (c, b, a)
 
-  let swirl_right = swirlRight
+  let rotate_right = rotateRight
 
   let toList ((a, b, c) : ('a * 'a * 'a)) : 'a list = [a; b; c]
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -236,8 +236,6 @@ module Tuple2 : sig
 
   val second : ('a * 'b) -> 'b
 
-  val map : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
-
   val mapFirst : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
   val map_first : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
@@ -273,8 +271,6 @@ module Tuple3 : sig
   val init : ('a * 'b * 'c) -> ('a * 'b)
 
   val tail : ('a * 'b * 'c) -> ('b * 'c)
-
-  val map : f:('c -> 'x) -> ('a * 'b * 'c) -> ('a * 'b * 'x)
 
   val mapFirst : f:('a -> 'x) -> ('a * 'b * 'c) -> ('x * 'b *'c)
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -270,7 +270,7 @@ module Tuple3 : sig
   
   val third : ('a * 'b * 'c) -> 'c
 
-  val head : ('a * 'b * 'c) -> ('a * 'b)
+  val init : ('a * 'b * 'c) -> ('a * 'b)
 
   val tail : ('a * 'b * 'c) -> ('b * 'c)
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -232,21 +232,33 @@ end
 module Tuple2 : sig
   val create : 'a -> 'b -> 'a * 'b
 
-  val first : 'a * 'b -> 'a
+  val first : ('a * 'b) -> 'a
 
-  val second : 'a * 'b -> 'b
+  val second : ('a * 'b) -> 'b
 
-  val mapFirst : f:('a -> 'x) -> 'a * 'b -> 'x * 'b
+  val map : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val map_first : f:('a -> 'x) -> 'a * 'b -> 'x * 'b
+  val mapFirst : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
-  val mapSecond : f:('b -> 'y) -> 'a * 'b -> 'a * 'y
+  val map_first : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
-  val map_second : f:('b -> 'y) -> 'a * 'b -> 'a * 'y
+  val mapSecond : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val mapBoth : f:('a -> 'x) -> g:('b -> 'y) -> 'a * 'b -> 'x * 'y
+  val map_second : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val map_both : f:('a -> 'x) -> g:('b -> 'y) -> 'a * 'b -> 'x * 'y
+  val mapEach : f:('a -> 'x) -> g:('b -> 'y) -> ('a * 'b) -> ('x * 'y)
+
+  val map_each : f:('a -> 'x) -> g:('b -> 'y) -> ('a * 'b) -> ('x * 'y)
+
+  val mapAll : f:('a -> 'b) -> ('a * 'a) -> ('b * 'b)
+
+  val map_all : f:('a -> 'b) -> ('a * 'a) -> ('b * 'b)
+
+  val swap : ('a * 'b) -> ('b * 'a)
+
+  val toList : ('a * 'a) -> 'a list
+
+  val to_list : ('a * 'a) -> 'a list
 end
 
 module Tuple3 : sig
@@ -257,6 +269,12 @@ module Tuple3 : sig
   val second : ('a * 'b * 'c) -> 'b
   
   val third : ('a * 'b * 'c) -> 'c
+
+  val head : ('a * 'b * 'c) -> ('a * 'b)
+
+  val tail : ('a * 'b * 'c) -> ('b * 'c)
+
+  val map : f:('c -> 'x) -> ('a * 'b * 'c) -> ('a * 'b * 'x)
 
   val mapFirst : f:('a -> 'x) -> ('a * 'b * 'c) -> ('x * 'b *'c)
 
@@ -273,6 +291,22 @@ module Tuple3 : sig
   val mapEach : f:('a -> 'x) -> g:('b -> 'y) -> h:('c -> 'z) -> ('a * 'b * 'c) -> ('x * 'y * 'z)
 
   val map_each : f:('a -> 'x) -> g:('b -> 'y) -> h:('c -> 'z) -> ('a * 'b * 'c) -> ('x * 'y * 'z)
+
+  val mapAll : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
+
+  val map_all : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
+
+  val swirlLeft : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  
+  val swirl_left : ('a * 'b * 'c) -> ('c * 'a * 'b)
+
+  val swirlRight : ('a * 'b * 'c) -> ('b * 'c * 'a)
+
+  val swirl_right : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  
+  val toList : ('a * 'a * 'a) -> 'a list
+
+  val to_list : ('a * 'a * 'a) -> 'a list
 end
 
 module String : sig

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -296,13 +296,13 @@ module Tuple3 : sig
 
   val map_all : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
 
-  val swirlLeft : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  val rotateLeft : ('a * 'b * 'c) -> ('b * 'c * 'a)
   
-  val swirl_left : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  val rotate_left : ('a * 'b * 'c) -> ('b * 'c * 'a)
 
-  val swirlRight : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  val rotateRight : ('a * 'b * 'c) -> ('c * 'a * 'b)
 
-  val swirl_right : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  val rotate_right : ('a * 'b * 'c) -> ('c * 'a * 'b)
   
   val toList : ('a * 'a * 'a) -> 'a list
 

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -47,7 +47,7 @@ module Tuple3 = struct
   
   let third ((_, _, c) : 'a * 'b * 'c) : 'c = c
 
-  let head ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
+  let init ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
 
   let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
 

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -73,13 +73,13 @@ module Tuple3 = struct
 
   let map_all = mapAll
 
-  let swirlLeft ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
+  let rotateLeft ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
 
-  let swirl_left = swirlLeft
+  let rotate_left = rotateLeft
 
-  let swirlRight ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
+  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'b * 'a) = (c, b, a)
 
-  let swirl_right = swirlRight
+  let rotate_right = rotateRight
 
   let toList ((a, b, c) : ('a * 'a * 'a)) : 'a list = [a; b; c]
 

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -13,17 +13,29 @@ module Tuple2 = struct
 
   let second ((_, b) : 'a * 'b) : 'b = b
 
+  let map ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
+
   let mapFirst ~(f : 'a -> 'x) ((a, b) : 'a * 'b) : 'x * 'b = (f a, b)
 
   let map_first = mapFirst
 
-  let mapSecond ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
+  let mapSecond = map
 
   let map_second = mapSecond
 
-  let mapBoth ~(f : 'a -> 'x) ~(g : 'b -> 'y) ((a, b) : 'a * 'b) : 'x * 'y = (f a, g b)
+  let mapEach ~(f : 'a -> 'x) ~(g : 'b -> 'y) ((a, b) : 'a * 'b) : 'x * 'y = (f a, g b)
+
+  let map_each = mapEach
   
-  let map_both = mapBoth
+  let mapAll ~(f : 'a -> 'b) (a1, a2) = (f a1, f a2)
+
+  let map_all = mapAll
+
+  let swap (a, b) = (b, a)
+
+  let toList (a, b) = [a; b]
+
+  let to_list = toList
 end
 
 module Tuple3 = struct
@@ -35,6 +47,12 @@ module Tuple3 = struct
   
   let third ((_, _, c) : 'a * 'b * 'c) : 'c = c
 
+  let head ((a, b, _) : 'a * 'b * 'c): ('a * 'b) = (a, b)
+
+  let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
+
+  let map ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
+
   let mapFirst ~(f : 'a -> 'x) ((a, b, c) : 'a * 'b * 'c) : 'x * 'b *'c = (f a, b, c)
 
   let map_first = mapFirst
@@ -43,13 +61,29 @@ module Tuple3 = struct
 
   let map_second = mapSecond
 
-  let mapThird ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
+  let mapThird = map
 
   let map_third = mapThird
 
   let mapEach ~(f : 'a -> 'x) ~(g : 'b -> 'y) ~(h : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'x * 'y * 'z = (f a, g b, h c)
 
   let map_each = mapEach
+
+  let mapAll ~(f: 'a -> 'b) (a1, a2, a3) = (f a1, f a2, f a3)
+
+  let map_all = mapAll
+
+  let swirlLeft ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
+
+  let swirl_left = swirlLeft
+
+  let swirlRight ((a, b, c) : 'a * 'b * 'c) : ('b * 'c * 'a) = (b, c, a)
+
+  let swirl_right = swirlRight
+
+  let toList ((a, b, c) : ('a * 'a * 'a)) : 'a list = [a; b; c]
+
+  let to_list = toList
 end
 
 module List = struct

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -13,13 +13,11 @@ module Tuple2 = struct
 
   let second ((_, b) : 'a * 'b) : 'b = b
 
-  let map ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
-
   let mapFirst ~(f : 'a -> 'x) ((a, b) : 'a * 'b) : 'x * 'b = (f a, b)
 
   let map_first = mapFirst
 
-  let mapSecond = map
+  let mapSecond ~(f : 'b -> 'y) ((a, b) : 'a * 'b) : 'a * 'y = (a, f b)
 
   let map_second = mapSecond
 
@@ -51,8 +49,6 @@ module Tuple3 = struct
 
   let tail ((_, b, c) : 'a * 'b * 'c): ('b * 'c) = (b, c)
 
-  let map ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
-
   let mapFirst ~(f : 'a -> 'x) ((a, b, c) : 'a * 'b * 'c) : 'x * 'b *'c = (f a, b, c)
 
   let map_first = mapFirst
@@ -61,7 +57,7 @@ module Tuple3 = struct
 
   let map_second = mapSecond
 
-  let mapThird = map
+  let mapThird ~(f : 'c -> 'z) ((a, b, c) : 'a * 'b * 'c) : 'a * 'b * 'z = (a, b, f c)
 
   let map_third = mapThird
 
@@ -77,7 +73,7 @@ module Tuple3 = struct
 
   let rotate_left = rotateLeft
 
-  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'b * 'a) = (c, b, a)
+  let rotateRight ((a, b, c) : 'a * 'b * 'c) : ('c * 'a * 'b) = (c, a, b)
 
   let rotate_right = rotateRight
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -236,8 +236,6 @@ module Tuple2 : sig
 
   val second : ('a * 'b) -> 'b
 
-  val map : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
-
   val mapFirst : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
   val map_first : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
@@ -273,8 +271,6 @@ module Tuple3 : sig
   val init : ('a * 'b * 'c) -> ('a * 'b)
 
   val tail : ('a * 'b * 'c) -> ('b * 'c)
-
-  val map : f:('c -> 'x) -> ('a * 'b * 'c) -> ('a * 'b * 'x)
 
   val mapFirst : f:('a -> 'x) -> ('a * 'b * 'c) -> ('x * 'b *'c)
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -270,7 +270,7 @@ module Tuple3 : sig
   
   val third : ('a * 'b * 'c) -> 'c
 
-  val head : ('a * 'b * 'c) -> ('a * 'b)
+  val init : ('a * 'b * 'c) -> ('a * 'b)
 
   val tail : ('a * 'b * 'c) -> ('b * 'c)
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -232,21 +232,33 @@ end
 module Tuple2 : sig
   val create : 'a -> 'b -> 'a * 'b
 
-  val first : 'a * 'b -> 'a
+  val first : ('a * 'b) -> 'a
 
-  val second : 'a * 'b -> 'b
+  val second : ('a * 'b) -> 'b
 
-  val mapFirst : f:('a -> 'x) -> 'a * 'b -> 'x * 'b
+  val map : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val map_first : f:('a -> 'x) -> 'a * 'b -> 'x * 'b
+  val mapFirst : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
-  val mapSecond : f:('b -> 'y) -> 'a * 'b -> 'a * 'y
+  val map_first : f:('a -> 'x) -> ('a * 'b) -> ('x * 'b)
 
-  val map_second : f:('b -> 'y) -> 'a * 'b -> 'a * 'y
+  val mapSecond : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val mapBoth : f:('a -> 'x) -> g:('b -> 'y) -> 'a * 'b -> 'x * 'y
+  val map_second : f:('b -> 'y) -> ('a * 'b) -> ('a * 'y)
 
-  val map_both : f:('a -> 'x) -> g:('b -> 'y) -> 'a * 'b -> 'x * 'y
+  val mapEach : f:('a -> 'x) -> g:('b -> 'y) -> ('a * 'b) -> ('x * 'y)
+
+  val map_each : f:('a -> 'x) -> g:('b -> 'y) -> ('a * 'b) -> ('x * 'y)
+
+  val mapAll : f:('a -> 'b) -> ('a * 'a) -> ('b * 'b)
+
+  val map_all : f:('a -> 'b) -> ('a * 'a) -> ('b * 'b)
+
+  val swap : ('a * 'b) -> ('b * 'a)
+
+  val toList : ('a * 'a) -> 'a list
+
+  val to_list : ('a * 'a) -> 'a list
 end
 
 module Tuple3 : sig
@@ -257,6 +269,12 @@ module Tuple3 : sig
   val second : ('a * 'b * 'c) -> 'b
   
   val third : ('a * 'b * 'c) -> 'c
+
+  val head : ('a * 'b * 'c) -> ('a * 'b)
+
+  val tail : ('a * 'b * 'c) -> ('b * 'c)
+
+  val map : f:('c -> 'x) -> ('a * 'b * 'c) -> ('a * 'b * 'x)
 
   val mapFirst : f:('a -> 'x) -> ('a * 'b * 'c) -> ('x * 'b *'c)
 
@@ -273,6 +291,22 @@ module Tuple3 : sig
   val mapEach : f:('a -> 'x) -> g:('b -> 'y) -> h:('c -> 'z) -> ('a * 'b * 'c) -> ('x * 'y * 'z)
 
   val map_each : f:('a -> 'x) -> g:('b -> 'y) -> h:('c -> 'z) -> ('a * 'b * 'c) -> ('x * 'y * 'z)
+
+  val mapAll : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
+
+  val map_all : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
+
+  val swirlLeft : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  
+  val swirl_left : ('a * 'b * 'c) -> ('c * 'a * 'b)
+
+  val swirlRight : ('a * 'b * 'c) -> ('b * 'c * 'a)
+
+  val swirl_right : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  
+  val toList : ('a * 'a * 'a) -> 'a list
+
+  val to_list : ('a * 'a * 'a) -> 'a list
 end
 
 module String : sig

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -296,13 +296,13 @@ module Tuple3 : sig
 
   val map_all : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
 
-  val swirlLeft : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  val rotateLeft : ('a * 'b * 'c) -> ('b * 'c * 'a)
   
-  val swirl_left : ('a * 'b * 'c) -> ('c * 'a * 'b)
+  val rotate_left : ('a * 'b * 'c) -> ('b * 'c * 'a)
 
-  val swirlRight : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  val rotateRight : ('a * 'b * 'c) -> ('c * 'a * 'b)
 
-  val swirl_right : ('a * 'b * 'c) -> ('b * 'c * 'a)
+  val rotate_right : ('a * 'b * 'c) -> ('c * 'a * 'b)
   
   val toList : ('a * 'a * 'a) -> 'a list
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -21,11 +21,19 @@ let t_Tuple2 () =
 
   AT.check AT.int "second" (Tuple2.second (3, 4)) 4;
 
+  AT.check (AT.pair AT.string (AT.float 0.)) "map" (Tuple2.map ~f:sqrt ("stressed", 16.)) ("stressed", 4.);
+
   AT.check (AT.pair AT.string AT.int) "mapFirst" (Tuple2.mapFirst ~f:String.reverse ("stressed", 16)) ("desserts", 16);
 
   AT.check (AT.pair AT.string (AT.float 0.)) "mapSecond" (Tuple2.mapSecond ~f:sqrt ("stressed", 16.)) ("stressed", 4.);
 
-  AT.check (AT.pair AT.string (AT.float 0.)) "mapBoth" (Tuple2.mapBoth ~f:String.reverse ~g:sqrt ("stressed", 16.)) ("desserts", 4.);
+  AT.check (AT.pair AT.string (AT.float 0.)) "mapEach" (Tuple2.mapEach ~f:String.reverse ~g:sqrt ("stressed", 16.)) ("desserts", 4.);
+
+  AT.check (AT.pair AT.string AT.string) "mapAll" (Tuple2.mapAll ~f:String.reverse ("was", "stressed")) ("saw", "desserts");
+
+  AT.check (AT.pair AT.int AT.int) "swap" (Tuple2.swap (3, 4)) (4, 3);
+
+  AT.check (AT.list AT.int) "toList" (Tuple2.toList (3, 4)) [3; 4;];
 
   ()
 
@@ -35,23 +43,37 @@ let trio a b c =
   AT.testable pp eq
 
 let t_Tuple3 () =
-    AT.check (trio AT.int AT.int AT.int) "create" (Tuple3.create 3 4 5) (3, 4, 5);
+  AT.check (trio AT.int AT.int AT.int) "create" (Tuple3.create 3 4 5) (3, 4, 5);
 
-    AT.check AT.int "first" (Tuple3.first (3, 4, 5)) 3;
+  AT.check AT.int "first" (Tuple3.first (3, 4, 5)) 3;
 
-    AT.check AT.int "second" (Tuple3.second (3, 4, 5)) 4;      
+  AT.check AT.int "second" (Tuple3.second (3, 4, 5)) 4;      
 
-    AT.check AT.int "third" (Tuple3.third (3, 4, 5)) 5;      
+  AT.check AT.int "third" (Tuple3.third (3, 4, 5)) 5;      
 
-    AT.check (trio AT.string AT.int AT.bool) "mapFirst" (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) ("desserts", 16, false);
+  AT.check (AT.pair AT.int AT.int) "head" (Tuple3.head (3, 4, 5)) (3, 4);      
 
-    AT.check (trio AT.string (AT.float 0.) AT.bool) "mapSecond" (Tuple3.mapSecond ~f:sqrt ("stressed", 16., false)) ("stressed", 4., false);
+  AT.check (AT.pair AT.int AT.int) "tail" (Tuple3.tail (3, 4, 5)) (4, 5);      
 
-    AT.check (trio AT.string AT.int AT.bool) "mapThird" (Tuple3.mapThird ~f:not ("stressed", 16, false)) ("stressed", 16, true);
+  AT.check (trio AT.string AT.int AT.bool) "map" (Tuple3.map ~f:not ("stressed", 16, false)) ("stressed", 16, true);
 
-    AT.check (trio AT.string (AT.float 0.) AT.bool) "mapEach" (Tuple3.mapEach ~f:String.reverse ~g:sqrt ~h:not ("stressed", 16., false)) ("desserts", 4., true);
+  AT.check (trio AT.string AT.int AT.bool) "mapFirst" (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) ("desserts", 16, false);
 
-    ()
+  AT.check (trio AT.string (AT.float 0.) AT.bool) "mapSecond" (Tuple3.mapSecond ~f:sqrt ("stressed", 16., false)) ("stressed", 4., false);
+
+  AT.check (trio AT.string AT.int AT.bool) "mapThird" (Tuple3.mapThird ~f:not ("stressed", 16, false)) ("stressed", 16, true);
+
+  AT.check (trio AT.string (AT.float 0.) AT.bool) "mapEach" (Tuple3.mapEach ~f:String.reverse ~g:sqrt ~h:not ("stressed", 16., false)) ("desserts", 4., true);
+
+  AT.check (trio AT.string AT.string AT.string) "mapAll" (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) ("saw", "desserts", "won");
+  
+  AT.check (trio AT.int AT.int AT.int) "swirlLeft" (Tuple3.swirlLeft (3, 4, 5)) (5, 3, 4);
+  
+  AT.check (trio AT.int AT.int AT.int) "swirlRight" (Tuple3.swirlRight (3, 4, 5)) (4, 5, 3);
+
+  AT.check (AT.list AT.int) "toList" (Tuple3.toList (3, 4, 5)) [3; 4; 5;];
+
+  ()
 
 let suite = [
   ("String", `Quick, t_String); 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -21,8 +21,6 @@ let t_Tuple2 () =
 
   AT.check AT.int "second" (Tuple2.second (3, 4)) 4;
 
-  AT.check (AT.pair AT.string (AT.float 0.)) "map" (Tuple2.map ~f:sqrt ("stressed", 16.)) ("stressed", 4.);
-
   AT.check (AT.pair AT.string AT.int) "mapFirst" (Tuple2.mapFirst ~f:String.reverse ("stressed", 16)) ("desserts", 16);
 
   AT.check (AT.pair AT.string (AT.float 0.)) "mapSecond" (Tuple2.mapSecond ~f:sqrt ("stressed", 16.)) ("stressed", 4.);
@@ -55,8 +53,6 @@ let t_Tuple3 () =
 
   AT.check (AT.pair AT.int AT.int) "tail" (Tuple3.tail (3, 4, 5)) (4, 5);      
 
-  AT.check (trio AT.string AT.int AT.bool) "map" (Tuple3.map ~f:not ("stressed", 16, false)) ("stressed", 16, true);
-
   AT.check (trio AT.string AT.int AT.bool) "mapFirst" (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) ("desserts", 16, false);
 
   AT.check (trio AT.string (AT.float 0.) AT.bool) "mapSecond" (Tuple3.mapSecond ~f:sqrt ("stressed", 16., false)) ("stressed", 4., false);
@@ -67,9 +63,9 @@ let t_Tuple3 () =
 
   AT.check (trio AT.string AT.string AT.string) "mapAll" (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) ("saw", "desserts", "won");
   
-  AT.check (trio AT.int AT.int AT.int) "rotateLeft" (Tuple3.rotateLeft (3, 4, 5)) (5, 3, 4);
+  AT.check (trio AT.int AT.int AT.int) "rotateLeft" (Tuple3.rotateLeft (3, 4, 5)) (4, 5, 3);
   
-  AT.check (trio AT.int AT.int AT.int) "rotateRight" (Tuple3.rotateRight (3, 4, 5)) (4, 5, 3);
+  AT.check (trio AT.int AT.int AT.int) "rotateRight" (Tuple3.rotateRight (3, 4, 5)) (5, 3, 4);
 
   AT.check (AT.list AT.int) "toList" (Tuple3.toList (3, 4, 5)) [3; 4; 5;];
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -51,7 +51,7 @@ let t_Tuple3 () =
 
   AT.check AT.int "third" (Tuple3.third (3, 4, 5)) 5;      
 
-  AT.check (AT.pair AT.int AT.int) "head" (Tuple3.head (3, 4, 5)) (3, 4);      
+  AT.check (AT.pair AT.int AT.int) "init" (Tuple3.init (3, 4, 5)) (3, 4);      
 
   AT.check (AT.pair AT.int AT.int) "tail" (Tuple3.tail (3, 4, 5)) (4, 5);      
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -67,9 +67,9 @@ let t_Tuple3 () =
 
   AT.check (trio AT.string AT.string AT.string) "mapAll" (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) ("saw", "desserts", "won");
   
-  AT.check (trio AT.int AT.int AT.int) "swirlLeft" (Tuple3.swirlLeft (3, 4, 5)) (5, 3, 4);
+  AT.check (trio AT.int AT.int AT.int) "rotateLeft" (Tuple3.rotateLeft (3, 4, 5)) (5, 3, 4);
   
-  AT.check (trio AT.int AT.int AT.int) "swirlRight" (Tuple3.swirlRight (3, 4, 5)) (4, 5, 3);
+  AT.check (trio AT.int AT.int AT.int) "rotateRight" (Tuple3.rotateRight (3, 4, 5)) (4, 5, 3);
 
   AT.check (AT.list AT.int) "toList" (Tuple3.toList (3, 4, 5)) [3; 4; 5;];
 


### PR DESCRIPTION
I have deviated slightly from the Elm extras package.
- Tuple2.mapBoth -> Tuple2.mapEach so the names are consistent with the same function in Tuple3
- swilll -> swirlLeft & swirl -> swirlRight (I assume that’s what the l and r stand for) to be a little more explicit
- init & tail -> head & tail. `init` doesn’t seem like a great name to me (short for initial?) as it doesn’t correspond with `tail`. `head` doesn’t seem ideal either as without looking at the signature I would guess that `head` behaved the same way as `first`