### PR TITLE
Make splitWhen consistent with splitAt.

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -104,6 +104,13 @@ let () =
       test "partition one element" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1]) |> toEqual ([], [1]));
       test "partition four elements" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) |> toEqual ([2;4], [1;3]));
     );
+ 
+    describe "split_when" (fun () ->
+      test "split_when four elements" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) |> toEqual ([1;3], [2;4]));
+      test "split_when at zero" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) |> toEqual ([], [2;4;6]));
+      test "split_when at end" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;5]) |> toEqual ([1;3;5], []));
+      test "split_when empty list" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
+    );
   );
 
   describe "String" (fun () ->

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -277,9 +277,10 @@ module List = struct
 
   let insert_at = insertAt
 
-  let splitWhen ~(f : 'a -> bool) (l : 'a list) : ('a list * 'a list) option =
-    findIndex ~f l |. Belt.Option.map (fun index -> splitAt ~index l)
-
+  let splitWhen ~(f : 'a -> bool) (l : 'a list) : ('a list * 'a list) =
+    match findIndex ~f l with
+      | Some index -> splitAt ~index l
+      | None -> (l, []) 
 
   let split_when = splitWhen
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -756,9 +756,9 @@ module List : sig
 
   val insert_at : index:int -> value:'a -> 'a list -> 'a list
 
-  val splitWhen : f:('a -> bool) -> 'a list -> ('a list * 'a list) option
+  val splitWhen : f:('a -> bool) -> 'a list -> 'a list * 'a list
 
-  val split_when : f:('a -> bool) -> 'a list -> ('a list * 'a list) option
+  val split_when : f:('a -> bool) -> 'a list -> 'a list * 'a list
 
   val intersperse : 'a -> 'a list -> 'a list
 

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -356,9 +356,10 @@ module List = struct
 
   let insert_at = insertAt
 
-  let splitWhen ~(f : 'a -> bool) (list : 'a list) : ('a list * 'a list) option
-      =
-    findIndex ~f list |> Base.Option.map ~f:(fun index -> splitAt ~index list)
+  let splitWhen ~(f : 'a -> bool) (l : 'a list) : ('a list * 'a list) =
+    match findIndex ~f l with
+      | Some index -> splitAt ~index l
+      | None -> (l, []) 
 
 
   let split_when = splitWhen

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -137,9 +137,9 @@ module List : sig
 
   val insert_at : index:int -> value:'a -> 'a list -> 'a list
 
-  val splitWhen : f:('a -> bool) -> 'a list -> ('a list * 'a list) option
+  val splitWhen : f:('a -> bool) -> 'a list -> 'a list * 'a list
 
-  val split_when : f:('a -> bool) -> 'a list -> ('a list * 'a list) option
+  val split_when : f:('a -> bool) -> 'a list -> 'a list * 'a list
 
   val intersperse : 'a -> 'a list -> 'a list
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -75,6 +75,11 @@ let t_List () =
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition one element" (List.partition ~f:(fun x -> x mod 2 = 0) [1]) ([], [1]);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition four elements" (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) ([2;4], [1;3]);
 
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when four elements" (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) ([1;3], [2;4])
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when at zero" (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) ([], [2;4;6]);
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when at end" (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;5]) ([1;3;5], []);
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when empty list" (List.split_when ~f:(fun x -> x mod 2 = 0) []) ([], []);
+
   ()
 
 let t_String () =

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -75,7 +75,7 @@ let t_List () =
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition one element" (List.partition ~f:(fun x -> x mod 2 = 0) [1]) ([], [1]);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition four elements" (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) ([2;4], [1;3]);
 
-  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when four elements" (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) ([1;3], [2;4])
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when four elements" (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) ([1;3], [2;4]);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when at zero" (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) ([], [2;4;6]);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when at end" (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;5]) ([1;3;5], []);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "split_when empty list" (List.split_when ~f:(fun x -> x mod 2 = 0) []) ([], []);


### PR DESCRIPTION
Is there a compelling reason for `splitWhen` to return an `option` value? 

Right now, when there is no item satisfying the predicate in `splitWhen`, it returns `None`. This pull request suggests instead returning a non-option tuple with an empty list as its second item. This makes `splitWhen`’s behavior consistent with `splitAt` when given an `~index` equal to the list length.

```
let even x = (x mod 2 == 0)
splitWhen ~f:even  [5; 1; 2; 6; 3] = ([5; 1], [2; 6; 3])
splitWhen ~f:even  [2; 6; 5] = ([], [2; 6; 5])
splitWhen ~f:even [5; 1; 3] = ([5; 1; 3], [])
splitWhen ~f:even [] = ([], [])
```