### PR TITLE
Add the Array module

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -3,6 +3,321 @@ open Jest
 open Expect
 
 let () =
+  describe "Array" (fun () ->
+    describe "empty" (fun () -> 
+      test "has length zero" (fun () -> expect Array.(empty |> length) |> toEqual 0);
+      test "equals the empty array literal" (fun () -> expect (Array.empty) |> toEqual [||]);
+    );
+
+    describe "singleton" (fun () -> 
+      test "equals an array literal of the same value" (fun () -> expect (Array.singleton 1234) |> toEqual [|1234|]);
+      test "has length one" (fun () -> expect Array.(singleton 1 |> length) |> toEqual 1);
+    );
+
+    describe "length" (fun () -> 
+      test "equals an array literal of the same value" (fun () -> expect (Array.length [||]) |> toEqual 0);
+      test "has length one" (fun () -> expect (Array.length [|'a'|]) |> toEqual 1);
+      test "has length two" (fun () -> expect (Array.length [|"a"; "b"|]) |> toEqual 2);
+    );
+
+    describe "isEmpty" (fun () -> 
+      test "returns true for empty array literals" (fun () -> 
+        expect (Array.isEmpty [||]) |> toEqual true);
+
+      test "returns false for literals with a non-zero number of elements" (fun () -> 
+        expect (Array.isEmpty [|1234|]) |> toEqual false);
+    );
+
+    describe "initialize" (fun () -> 
+      test "create empty array" (fun () -> 
+        expect (Array.initialize ~length:0 ~f:identity) |> toEqual [||]);
+
+      test "negative length gives an empty array" (fun () -> 
+        expect (Array.initialize ~length:(-1) ~f:identity) |> toEqual [||]);
+
+      test "create array with initialize" (fun () -> 
+        expect (Array.initialize ~length:3 ~f:identity) |> toEqual [|0;1;2|]);
+    );
+
+    describe "repeat" (fun () -> 
+      test "length zero creates an empty array" (fun () -> 
+        expect (Array.repeat 0 ~length:0) |> toEqual [||]);
+
+      test "negative length gives an empty array" (fun () -> 
+        expect (Array.repeat ~length:(-1) 0) |> toEqual [||]);
+
+      test "create array of ints" (fun () -> 
+        expect (Array.repeat 0 ~length:3) |> toEqual [|0;0;0|]);
+
+      test "create array strings" (fun () -> 
+        expect (Array.repeat "cat" ~length:3) |> toEqual [|"cat";"cat";"cat"|]);
+    );
+
+    describe "range" (fun () -> 
+      test "returns an array of the integers from zero and upto but not including [to]" (fun () -> 
+        expect (Array.range 5) |> toEqual [|0; 1; 2; 3; 4|]);
+
+      test "returns an empty array when [to] is zero" (fun () -> 
+        expect (Array.range 0) |> toEqual [||]);
+
+      test "takes an optional [from] argument to start create empty array" (fun () -> 
+        expect (Array.range ~from:2 5) |> toEqual [|2; 3; 4|]);
+
+      test "can start from negative values" (fun () -> 
+        expect (Array.range ~from:(-2) 3) |> toEqual [|-2; -1; 0; 1; 2|]);
+
+      test "returns an empty array when [from] > [to_]" (fun () -> 
+        expect (Array.range ~from:5 0) |> toEqual [||]);
+    );
+
+    describe "fromList" (fun () -> 
+      test "transforms a list into an array of the same elements" (fun () -> 
+        expect Array.(fromList [1;2;3]) |> toEqual [|1;2;3|]);
+    );
+
+    describe "toList" (fun () -> 
+      test "transform an array into a list of the same elements" (fun () -> 
+        expect (Array.toList [|1;2;3|]) |> toEqual [1;2;3]);
+    );
+
+    describe "toIndexedList" (fun () -> 
+      test "returns an empty list for an empty array" (fun () -> 
+        expect (Array.toIndexedList [||]) |> toEqual []);
+
+      test "transforms an array into a list of tuples" (fun () -> 
+        expect (Array.toIndexedList [|"cat"; "dog"|]) |> toEqual [(0, "cat"); (1, "dog")]);
+    );
+
+    describe "get" (fun () -> 
+      test "returns Some for an in-bounds indexe" (fun () -> 
+        expect (Array.get ~index:2 [|"cat"; "dog"; "eel"|]) |> toEqual (Some "eel"));
+
+      test "returns None for an out of bounds index" (fun () -> 
+        expect (Array.get ~index:5 [|0; 1; 2|]) |> toEqual None);
+
+      test "returns None for an empty array" (fun () -> 
+        expect (Array.get ~index:0 [||]) |> toEqual None);
+    );
+
+    describe "set" (fun () -> 
+      test "can be partially applied to set an element" (fun () -> 
+        let setZero = Array.set ~value:0 in
+        let numbers = [|1;2;3|] in
+        setZero numbers ~index:2;
+        setZero numbers ~index:1;
+        expect numbers |> toEqual [|1;0;0|]
+      );
+
+      test "can be partially applied to set an index" (fun () -> 
+        let setZerothElement = Array.set ~index:0 in
+        let animals = [|"ant"; "bat"; "cat"|] in    
+        setZerothElement animals ~value:"antelope";    
+        expect animals |> toEqual [|"antelope"; "bat"; "cat"|]);
+    );
+
+    describe "sum" (fun () -> 
+      test "equals zero for an empty array" (fun () -> 
+        expect (Array.sum [||]) |> toEqual 0);
+
+      test "adds up the elements on an integer array" (fun () -> 
+        expect (Array.sum [|1;2;3|]) |> toEqual 6);
+    );
+
+    describe "floatSum" (fun () -> 
+      test "equals zero for an empty array" (fun () -> 
+        expect (Array.floatSum [||]) |> toEqual 0.0);
+
+      test "adds up the elements of a float array" (fun () -> 
+        expect (Array.floatSum [|1.2;2.3;3.4|]) |> toEqual 6.9);
+    );
+
+    describe "filter" (fun () -> 
+      test "keep elements that [f] returns [true] for" (fun () -> 
+        expect (Array.filter ~f:Int.isEven [|1; 2; 3; 4; 5; 6|]) |> toEqual [|2; 4; 6|]);
+    );
+
+    describe "map" (fun () -> 
+      test "Apply a function [f] to every element in an array" (fun () -> 
+        expect (Array.map ~f:sqrt [|1.0; 4.0; 9.0|]) |> toEqual [|1.0; 2.0; 3.0|]);
+    );
+
+    describe "mapWithIndex" (fun () -> 
+      test "equals an array literal of the same value" (fun () -> 
+        expect (Array.mapWithIndex ~f:( * ) [|5; 5; 5|]) |> toEqual [|0; 5; 10|]);
+    );
+
+    describe "map2" (fun () -> 
+      test "works when the order of arguments to `f` is not important" (fun () -> 
+        expect (Array.map2 ~f:(+) [|1;2;3|] [|4;5;6|]) |> toEqual [|5;7;9|]);
+
+      test "works when the order of `f` is important" (fun () -> 
+        expect (Array.map2 ~f:Tuple2.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8|]) 
+        |> toEqual [|("alice",2);("bob",5);("chuck",7)|]);
+    );
+
+    test "map3" (fun () -> 
+      expect (
+        Array.map3 
+          ~f:Tuple3.create 
+          [|"alice"; "bob"; "chuck"|] 
+          [|2; 5; 7; 8;|] 
+          [|true; false; true; false|] 
+        ) 
+      |> toEqual [|("alice", 2, true); ("bob", 5, false); ("chuck", 7, true)|]);
+
+    test "flatMap" (fun () -> 
+      let duplicate n = [|n; n|] in
+      expect (Array.flatMap ~f:duplicate [|1; 2; 3|]) |> toEqual [|1; 1; 2; 2; 3; 3|]
+    );
+
+    describe "find" (fun () -> 
+      test "returns the first element which `f` returns true for" (fun () -> 
+        expect (Array.find ~f:Int.isEven [|1; 3; 4; 8;|]) |> toEqual (Some 4));
+
+      test "returns `None` if `f` returns false for all elements " (fun () -> 
+        expect (Array.find ~f:Int.isOdd [|0; 2; 4; 8;|]) |> toEqual None);
+
+      test "returns `None` for an empty array" (fun () -> 
+        expect (Array.find ~f:Int.isEven [||]) |> toEqual None);
+    );
+
+    describe "any" (fun () -> 
+      test "returns false for empty arrays" (fun () -> 
+        expect (Array.any [||] ~f:Int.isEven) |> toEqual false
+      );
+
+      test "returns true if at least one of the elements of an array return true for [f]" (fun () -> 
+        expect (Array.any [|1;3;4;5;7|] ~f:Int.isEven) |> toEqual true
+      );
+
+      test "returns false if all of the elements of an array return false for [f]" (fun () -> 
+        expect (Array.any [|1;3;5;7|] ~f:Int.isEven) |> toEqual false
+      );
+    );
+
+    describe "all" (fun () -> 
+      test "returns true for empty arrays" (fun () -> 
+        expect (Array.all ~f:Int.isEven [||]) |> toEqual true);
+
+      test "returns true if [f] returns true for all elements" (fun () -> 
+        expect (Array.all ~f:Int.isEven [|2;4|]) |> toEqual true);
+
+      test "returns false if a single element fails returns false for [f]" (fun () ->
+        expect (Array.all ~f:Int.isEven [|2;3|]) |> toEqual false);
+    );
+
+    test "append" (fun () -> 
+      expect (Array.append (Array.repeat ~length:2 42) (Array.repeat ~length:3 81)) |> toEqual  [|42; 42; 81; 81; 81|]
+    );
+
+    test "concatenate" (fun () -> 
+      expect (Array.concatenate [|[|1; 2|]; [|3|]; [|4; 5|]|]) |> toEqual [|1; 2; 3; 4; 5|]);
+
+    describe "intersperse" (fun () -> 
+      test "equals an array literal of the same value" (fun () -> 
+        expect (Array.intersperse ~sep:"on" [|"turtles"; "turtles"; "turtles"|]) 
+        |> toEqual [|"turtles"; "on"; "turtles"; "on"; "turtles"|]
+      );
+
+      test "equals an array literal of the same value" (fun () -> 
+        expect (Array.intersperse ~sep:0 [||]) |> toEqual [||]);
+    );
+
+    describe "slice" (fun () -> 
+      let array = [|0; 1; 2; 3; 4|] in
+      let positiveArrayLengths = [Array.length array; Array.length array + 1; 1000] in
+      let negativeArrayLengths = List.map ~f:Int.negate positiveArrayLengths in
+
+      test "should work with a positive `from`" (fun () -> 
+        expect (Array.slice ~from:1 array) |> toEqual [|1; 2; 3; 4|]);
+
+      test "should work with a negative `from`" (fun () -> 
+        expect (Array.slice ~from:(-1) array) |> toEqual [|4|]);
+
+      testAll "should work when `from` >= `length`" positiveArrayLengths (fun from -> 
+        expect (Array.slice ~from array) |> toEqual [||]);
+
+      testAll "should work when `from` <= negative `length`" negativeArrayLengths (fun from -> 
+        expect (Array.slice ~from array) |> toEqual array);
+
+      test "should work with a positive `to_`" (fun () -> 
+        expect (Array.slice ~from:0  ~to_:3 array) |> toEqual [|0; 1; 2|]);
+
+      test "should work with a negative `to_`" (fun () -> 
+        expect (Array.slice  ~from:1 ~to_:(-1) array) |> toEqual [|1; 2; 3|]);
+
+      testAll "should work when `to_` >= length" positiveArrayLengths (fun to_ -> 
+        expect (Array.slice ~from:0  ~to_ array) |> toEqual array);
+
+      testAll "should work when `to_` <= negative `length`" negativeArrayLengths (fun to_ -> 
+        expect (Array.slice ~from:0  ~to_ array) |> toEqual [||]);
+      
+      test "should work when both `from` and `to_` are negative and `from` < `to_`" (fun () -> 
+        expect (Array.slice ~from:(-2)  ~to_:(-1) array) |> toEqual [|3|]);
+
+      test "works when `from` >= `to_`" (fun () -> 
+        expect (Array.slice ~from:(4)  ~to_:(3) array) |> toEqual [||]);
+    );
+     
+    describe "foldLeft" (fun () -> 
+      test "works for an empty array" (fun () -> 
+        expect (Array.foldLeft [||] ~f:(^) ~initial:"") |> toEqual "");
+
+      test "works for an ascociative operator" (fun () -> 
+        expect (Array.foldLeft ~f:( * ) ~initial:1 (Array.repeat ~length:4 7)) |> toEqual 2401);
+
+      test "works when the order of arguments to `f` is important" (fun () -> 
+        expect (Array.foldLeft [|"a";"b";"c"|] ~f:(^) ~initial:"") |> toEqual "cba");
+
+      test "works when the order of arguments to `f` is important" (fun () -> 
+        expect (Array.foldLeft ~f:(fun element list -> element :: list) ~initial:[] [|1; 2; 3|]) |> toEqual [3; 2; 1]);
+    );
+
+    describe "foldRight" (fun () -> 
+      test "works for empty arrays" (fun () -> 
+        expect (Array.foldRight [||] ~f:(^) ~initial:"") |> toEqual "");
+
+      test "fold right" (fun () -> 
+        expect (Array.foldRight ~f:(+) ~initial:0 (Array.repeat ~length:3 5)) |> toEqual 15);
+
+      test "works when the order of arguments to `f` is important" (fun () -> 
+        expect (Array.foldRight [|"a";"b";"c"|] ~f:(^) ~initial:"") |> toEqual "abc");
+        
+      test "works when the order of arguments to `f` is important" (fun () -> 
+        expect (Array.foldRight ~f:(fun element list -> element :: list) ~initial:[] [|1; 2; 3|]) |> toEqual [1; 2; 3]);
+    );
+
+    describe "reverse" (fun () -> 
+      test "reverse empty array" (fun () -> expect (Array.reverse [||]) |> toEqual [||]);
+      test "reverse two elements" (fun () -> expect (Array.reverse [|0;1|]) |> toEqual [|1;0|]);
+      test "leaves the original array untouched" (fun () -> 
+        let array = [|0; 1; 2; 3;|] in
+        let _reversedArray = Array.reverse array in
+        expect array |> toEqual [|0; 1; 2; 3;|]
+      );
+    );
+
+    describe "reverseInPlace" (fun () -> 
+      test "alters an array in-place" (fun () -> 
+        let array = [|1;2;3|] in
+        Array.reverseInPlace array;
+        expect array |> toEqual [|3;2;1|]
+      );
+    );
+
+    test "forEach" (fun () -> 
+      let index = ref 0 in
+      let calledValues = [|0;0;0|] in
+      
+      Array.forEach [|1;2;3|] ~f:(fun value -> 
+        Array.set calledValues ~index:!index ~value;
+        index := !index + 1;
+      );
+      
+      expect calledValues |> toEqual [|1;2;3|]
+    );
+  );
+
   describe "Char" (fun () -> 
     test "toCode" (fun () -> expect (Char.toCode 'a') |> toEqual 97);
 
@@ -100,9 +415,9 @@ let () =
     );
 
     describe "partition" (fun () ->
-      test "partition empty list" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
-      test "partition one element" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1]) |> toEqual ([], [1]));
-      test "partition four elements" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) |> toEqual ([2;4], [1;3]));
+      test "empty list" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
+      test "one element" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1]) |> toEqual ([], [1]));
+      test "four elements" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) |> toEqual ([2;4], [1;3]));
     );
  
     describe "minimumBy" (fun () ->
@@ -126,10 +441,10 @@ let () =
     );
    
     describe "split_when" (fun () ->
-      test "split_when four elements" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) |> toEqual ([1;3], [2;4]));
-      test "split_when at zero" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) |> toEqual ([], [2;4;6]));
-      test "split_when at end" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;5]) |> toEqual ([1;3;5], []));
-      test "split_when empty list" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
+      test "empty list" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
+      test "at zero" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) |> toEqual ([], [2;4;6]));
+      test "four elements" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;2;4]) |> toEqual ([1;3], [2;4]));
+      test "at end" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [1;3;5]) |> toEqual ([1;3;5], []));
     );
   );
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -87,8 +87,6 @@ module Array = struct
 
   let concatenate (ars : 'a array array) : 'a array = Belt.Array.concatMany ars
 
-  let flatten = concatenate
-
   let intersperse ~(sep : 'a) (array : 'a array) : 'a array = 
     Belt.Array.makeBy
       (max 0 (length array * 2 - 1)) 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1,7 +1,3 @@
-module Caml = struct
-  module Array = Array
-end
-
 let ( <| ) a b = a b
 
 let ( >> ) (f1 : 'a -> 'b) (f2 : 'b -> 'c) : 'a -> 'c = fun x -> x |> f1 |> f2
@@ -94,8 +90,8 @@ module Array = struct
   let flatten = concatenate
 
   let intersperse ~(sep : 'a) (array : 'a array) : 'a array = 
-    Array.init
-      (max 0 (Array.length array * 2 - 1)) 
+    Belt.Array.makeBy
+      (max 0 (length array * 2 - 1)) 
       (fun i -> 
         if i mod 2 <> 0 then sep else array.(i / 2)
       )
@@ -115,7 +111,7 @@ module Array = struct
     in    
     
     if sliceFrom >= sliceTo then empty else (
-      Array.init (sliceTo - sliceFrom) (fun i -> array.(i + sliceFrom))
+      Belt.Array.makeBy (sliceTo - sliceFrom) (fun i -> array.(i + sliceFrom))
     )
 
   let foldLeft ~(f : 'a -> 'b -> 'b) ~(initial : 'b) (a : 'a array) : 'b =
@@ -169,7 +165,7 @@ module List = struct
 
   let elemIndex ~(value : 'a) (l : 'a list) : int option =
     l
-    |> Caml.Array.of_list
+    |> Belt.List.toArray
     |> Js.Array.findIndex (( = ) value)
     |> function -1 -> None | index -> Some index
 
@@ -886,7 +882,7 @@ module StrSet = struct
 
   let to_list = toList
 
-  let ofList (s : value list) : t = s |> Caml.Array.of_list |> Set.fromArray
+  let ofList (s : value list) : t = s |> Belt.List.toArray |> Set.fromArray
 
   let of_list = ofList
 
@@ -936,7 +932,7 @@ module IntSet = struct
 
   let to_list = toList
 
-  let ofList (s : value list) : t = s |> Caml.Array.of_list |> Set.fromArray
+  let ofList (s : value list) : t = s |> Belt.List.toArray |> Set.fromArray
 
   let of_list = ofList
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -140,8 +140,6 @@ module Array : sig
 
   val concatenate : 'a array array -> 'a array
 
-  val flatten : 'a array array -> 'a array
-
   val intersperse : sep:'a -> 'a array -> 'a array
 
   val slice : from:int -> ?to_:int -> 'a array -> 'a array

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -1,4 +1,4 @@
-(** Documentation for tablecloth.mli 
+(** Documentation for tablecloth.mli
 
 Function names that are all lower case have their descriptions and examples in both OCaml and ReasonML format.
 
@@ -35,7 +35,7 @@ val ( <| ) : ('a -> 'b) -> 'a -> 'b
 
   ```ocaml
 
-  let f = sqrt >> floor 
+  let f = sqrt >> floor
   f 17.0  = 4
   ```
 
@@ -55,7 +55,7 @@ val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 
   ```ocaml
 
-  let f = floor << sqrt 
+  let f = floor << sqrt
   f 3.5 = 1.7320508075688772
   ```
 
@@ -72,6 +72,98 @@ val ( << ) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
   function that does not alter the results of a computation.
 *)
 val identity : 'a -> 'a
+
+module Array : sig
+  val empty : 'a array
+
+  val singleton : 'a -> 'a array
+
+  val length : 'a array -> int
+
+  val isEmpty : 'a array -> bool
+
+  val is_empty : 'a array -> bool
+
+  val initialize : length:int -> f:(int -> 'a) -> 'a array
+
+  val repeat : length:int -> 'a -> 'a array
+
+  val range : ?from:int -> int -> int array
+
+  val fromList : 'a list -> 'a array
+
+  val from_list : 'a list -> 'a array
+
+  val toList : 'a array -> 'a list
+
+  val to_list : 'a array -> 'a list
+
+  val toIndexedList : 'a array -> (int* 'a) list
+
+  val to_indexed_list : 'a array -> (int* 'a) list
+
+  val get : index:int -> 'a array -> 'a option
+
+  val set : index:int -> value:'a -> 'a array -> unit
+
+  val sum : int array -> int
+
+  val floatSum : float array -> float
+
+  val float_sum : float array -> float
+
+  val filter : f:('a -> bool) -> 'a array -> 'a array
+
+  val map : f:('a -> 'b) -> 'a array -> 'b array
+
+  val mapWithIndex : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+
+  val map_with_index : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+
+  val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+
+  val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+
+  val map3 : f:('a -> 'b -> 'c -> 'd) -> 'a array -> 'b array -> 'c array -> 'd array
+
+  val flatMap : f:('a -> 'a array) -> 'a array -> 'a array
+
+  val flat_map : f:('a -> 'a array) -> 'a array -> 'a array
+
+  val find : f:('a -> bool) -> 'a array -> 'a option
+
+  val any : f:('a -> bool) -> 'a array -> bool
+
+  val all : f:('a -> bool) -> 'a array -> bool
+
+  val append : 'a array -> 'a array -> 'a array
+
+  val concatenate : 'a array array -> 'a array
+
+  val flatten : 'a array array -> 'a array
+
+  val intersperse : sep:'a -> 'a array -> 'a array
+
+  val slice : from:int -> ?to_:int -> 'a array -> 'a array
+
+  val foldLeft : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+
+  val fold_left : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+
+  val foldRight : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+
+  val fold_right : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+
+  val reverse : 'a array -> 'a array
+
+  val reverseInPlace : 'a array -> unit
+
+  val reverse_in_place : 'a array -> unit
+
+  val forEach : f:('a -> unit) -> 'a array -> unit
+
+  val for_each : f:('a -> unit) -> 'a array -> unit
+end
 
 module List : sig
   (**
@@ -106,7 +198,7 @@ module List : sig
 
   (**
     `floatSum(xs)` in ReasonML returns the sum of the given list of floats. (Same as `float_sum`.)
-    
+
     ### Example
 
     ```reason
@@ -117,7 +209,7 @@ module List : sig
 
   (**
     `float_sum(xs)` returns the sum of the given list of floats. (Same as `floatSum`.)
-    
+
     ### Example
 
     ```ocaml
@@ -135,7 +227,7 @@ module List : sig
     ```ocaml
     let cube_root (x : int) =
       ((float_of_int x) ** (1.0 /. 3.0) : float)
-      
+
     map ~f:cube_root [8; 1000; 1728] (* [2; 9.999..; 11.999..] *)
     ```
 
@@ -157,7 +249,7 @@ module List : sig
     ```reason
     let numbered = (idx: int, item: string): string =>
       string_of_int(idx) ++ ": " ++ item;
-      
+
     indexedMap(~f=numbered, ["zero", "one", "two"]) ==
       ["0: zero", "1: one", "2: two"]
     ```
@@ -196,7 +288,7 @@ module List : sig
     ```ocaml
     let discount (price: float) (percentage: float) =
       (price *. (1.0 -. (percentage /. 100.0)) : float)
-      
+
     map2 ~f:discount [100.0; 85.0; 30.0] [10.0; 20.0; 30.0] =
       [90.0; 68.0; 21.0]
     ```
@@ -204,7 +296,7 @@ module List : sig
     ```reason
     let discount = (price: float, percentage: float): float =>
       price *. (1.0 -. (percentage /. 100.0));
-      
+
     map2(~f=discount, [100.0, 85.0, 30.0], [10.0, 20.0, 30.0]) ==
       [90.0, 68.0, 21.0]
     ```
@@ -316,8 +408,8 @@ module List : sig
 
   (**
     `uniqueBy ~f:fcn xs` returns a new list containing only those elements from `xs`
-    that have a unique value when `fcn` is applied to them. 
-    
+    that have a unique value when `fcn` is applied to them.
+
     The function `fcn` takes as its single parameter an item from the list
     and returns a `string`. If the function generates the same string for two or more
     list items, only the first of them is retained. (Same as 'unique_by'.)
@@ -335,7 +427,7 @@ module List : sig
   (**
     `unique_by ~f:fcn xs` returns a new list containing only those elements from `xs`
     that have a unique value when `fcn` is applied to them.
-    
+
     The function `fcn` takes as its single parameter an item from the list
     and returns a `string`. If the function generates the same string for two or more
     list items, only the first of them is retained. (Same as 'uniqueBy'.)
@@ -353,7 +445,7 @@ module List : sig
   (**
     `getAt(~index=n, xs)` retrieves the value of the `n`th item in `xs`
     (with zero as the starting index) as `Some(value)`, or `None`
-    if `n` is less than zero or greater than the length of `xs`. 
+    if `n` is less than zero or greater than the length of `xs`.
 
     ### Example
 
@@ -388,7 +480,7 @@ module List : sig
     for any item in `x` in `xs`.
 
     ### Example
-    
+
     ```ocaml
     let even x = (x mod 2) = 0
     any ~f:even [1; 3; 4; 5] = true
@@ -475,7 +567,7 @@ module List : sig
     ### Example
 
     ```reason
-    filterMap(~f = (x) => if (x mod 2 == 0) {Some(- x)} else {None}, 
+    filterMap(~f = (x) => if (x mod 2 == 0) {Some(- x)} else {None},
       [1, 2, 3, 4]) == [-2, -4]
     ```
   *)
@@ -609,9 +701,9 @@ module List : sig
     to the list item at index position `n`. (The first item in a list has index zero.)
     If `n` is less than zero or greater than the number of items in `xs`,
     the new list is the same as the original list. (Same as `update_at`.)
-  
+
     ### Example
-    
+
     ```reason
     let double = (x) => {x * 2};
     updateAt(~index = 1, ~f = double, [1, 2, 3]) == [1, 4, 3];
@@ -626,9 +718,9 @@ module List : sig
     to the list item at index position `n`. (The first item in a list has index zero.)
     If `n` is less than zero or greater than the number of items in `xs`,
     the new list is the same as the original list. (Same as `updateAt`.)
-  
+
     ### Example
-    
+
     ```ocaml
     let double x = x * 2
     update_at ~index:1 ~f:double [1;2;3]  = [1;4;3]
@@ -695,14 +787,14 @@ module List : sig
 
   (**
     `cons item xs` (`cons(item, xs)` in ReasonML) prepends the `item` to `xs`.
-    
+
     ### Example
-    
+
     ```ocaml
     cons "one" ["two"; "three"] = ["one"; "two"; "three"]
     cons 42 [] = [42]
     ```
-    
+
     ```reason
     cons("one", ["two", "three"]) == ["one", "two", "three"];
     cons(42, []) == [42];
@@ -744,16 +836,16 @@ module List : sig
     `all ~f:predicate xs` (`all(~f=predicate, xs)` in ReasonML) returns `true`
     if all the elements in `xs` satisfy the `predicate` function, `false` otherwise.
     Note: `all` returns `true` if `xs` is the empty list.
-    
+
     ### Example
-    
+
     ```ocaml
     let even x = x mod 2 = 0
     all ~f:even [16; 22; 40] = true
     all ~f:even [16; 21; 40] = false
     all ~f:even [] = true
     ```
-    
+
     ```reason
     let even = (x) => {x mod 2 == 0};
     all(~f=even, [16, 22, 40]) == true;
@@ -767,13 +859,13 @@ module List : sig
     `tail xs` (`tail(xs)` in ReasonML) returns all except the first item in `xs`
     as a `Some` value when `xs` is not empty. If `xs` is the empty list,
     `tail` returns `None`.
-    
+
     ```ocaml
     tail [3; 4; 5] = Some [4; 5]
     tail [3] = Some []
     tail [] = None
     ```
-    
+
     ```reason
     tail([3, 4, 5]) == Some([4, 5]);
     tail([3]) == Some([]);
@@ -785,14 +877,14 @@ module List : sig
   (**
     `append xs ys` (`append(xs, ys)` in ReasonML) returns a new list with
     the elements of `xs` followed by the elements of `ys`.
-    
+
     ### Example
     ```ocaml
     append [1; 2] [3; 4; 5] = [1; 2; 3; 4; 5]
     append [] [6; 7] = [6; 7]
     append [8; 9] [] = [8; 9]
     ```
-    
+
     ```reason
     append([1, 2], [3, 4, 5]) == [1, 2, 3, 4, 5];
     append([], [6, 7]) == [6, 7];
@@ -805,9 +897,9 @@ module List : sig
     `removeAt(n, xs)` returns a new list with the item at the given index removed.
     If `n` is less than zero or greater than the length of `xs`, the new list is
     the same as the original. (Same as `remove_at`.)
-    
+
     ### Example
-    
+
     ```reason
     removeAt(~index=2, ["a", "b", "c", "d"] == ["a", "b", "d"]);
     removeAt(~index=-2, ["a", "b", "c", "d"] == ["a", "b", "c", "d"]);
@@ -820,9 +912,9 @@ module List : sig
     `remove_at n xs` returns a new list with the item at the given index removed.
     If `n` is less than zero or greater than the length of `xs`, the new list is
     the same as the original. (Same as `removeAt`.)
-    
+
     ### Example
-    
+
     ```ocaml
     remove_at ~index:2, ["a"; "b"; "c"; "d"] = ["a"; "b"; "d"]
     remove_at ~index:(-2) ["a"; "b"; "c"; "d"] = ["a"; "b"; "c"; "d"]
@@ -834,103 +926,103 @@ module List : sig
   (**
     `minimumBy(~f=fcn, xs)`, when given a non-empty list, returns the item in the list
     for which `fcn(item)` is a minimum. It is returned as `Some(item)`.
-    
+
     If given an empty list, `minimumBy` returns `None`. If more than one value has a minimum
     value for `fcn item`, the first one is returned.
-    
+
     The function provided takes a list item as its parameter and must return a value
     that can be compared---for example, a `string` or `int`. (Same as `minimum_by`.)
-    
+
     ### Example
-    
+
     ```reason
     let mod12 = (x) => (x mod 12);
     let hours = [7, 9, 15, 10, 3, 22];
     minimumBy(~f=mod12, hours) == Some(15);
     minimumBy(~f=mod12, []) == None;
     ```
-   *) 
+   *)
   val minimumBy : f:('a -> 'comparable) -> 'a list -> 'a option
 
   (**
     `minimum_by ~f:fcn, xs`, when given a non-empty list, returns the item in the list
     for which `fcn item` is a minimum. It is returned as `Some item`.
-    
+
     If given an empty list, `minimumBy` returns `None`. If more than one value has a minimum
     value for `fcn item`, the first one is returned.
-    
+
     The function provided takes a list item as its parameter and must return a value
     that can be compared---for example, a `string` or `int`. (Same as `minimumBy`.)
-    
+
     ### Example
-    
+
     ```ocaml
     let mod12 x = x mod 12
     let hours = [7; 9; 15; 10; 3; 22]
     minimum_by ~f:mod12 hours = Some 15
     minimum_by ~f:mod12 [] = None
     ```
-   *) 
+   *)
   val minimum_by : f:('a -> 'comparable) -> 'a list -> 'a option
-  
+
   (**
     `minimum xs` (`minimum(xs)` in ReasonML), when given a non-empty list, returns
     the item in the list with the minimum value. It is returned as `Some value`
-    (`Some(value) in ReasonML)`. If given an empty list, `maximum` returns `None`. 
-    
+    (`Some(value) in ReasonML)`. If given an empty list, `maximum` returns `None`.
+
     The items in the list must be of a type that can be compared---for example, a `string` or `int`.
-   *) 
+   *)
   val minimum: 'comparable list -> 'comparable option
 
   (**
     `maximumBy(~f=fcn, xs)`, when given a non-empty list, returns the item in the list
-    for which `fcn(item)` is a maximum. It is returned as `Some(item)`. 
-    
+    for which `fcn(item)` is a maximum. It is returned as `Some(item)`.
+
     If given an empty list, `maximumBy` returns `None`. If more than one value has a maximum
     value for `fcn item`, the first one is returned.
-    
+
     The function provided takes a list item as its parameter and must return a value
     that can be compared---for example, a `string` or `int`. (Same as `maximum_by`.)
-    
+
     ### Example
-    
+
     ```reason
     let mod12 = (x) => (x mod 12);
     let hours = [7, 9, 15, 10, 3, 22];
     maximumBy(~f=mod12, hours) == Some(10);
     maximumBy(~f=mod12 []) == None;
     ```
-   *) 
+   *)
   val maximumBy : f:('a -> 'comparable) -> 'a list -> 'a option
 
   (**
     `maximum_by ~f:fcn, xs`, when given a non-empty list, returns the item in the list
     for which `fcn item` is a maximum. It is returned as `Some item`.
-    
+
     If given an empty list, `maximumBy` returns `None`. If more than one value has a maximum
     value for `fcn item`, the first one is returned.
-    
+
     The function provided takes a list item as its parameter and must return a value
     that can be compared---for example, a `string` or `int`. (Same as `maximumBy`.)
-    
+
     ### Example
-    
+
     ```ocaml
     let mod12 x = x mod 12
     let hours = [7;9;15;10;3;22]
     maximum_by ~f:mod12 hours = Some 10
     maximum_by ~f:mod12 [] = None
     ```
-   *) 
+   *)
   val maximum_by : f:('a -> 'comparable) -> 'a list -> 'a option
 
   (**
     `maximum xs` (`maximum(xs)` in ReasonML), when given a non-empty list, returns
     the item in the list with the maximum value. It is returned as `Some value`
-    (`Some(value) in ReasonML)`. If given an empty list, `maximum` returns `None`. 
-    
+    (`Some(value) in ReasonML)`. If given an empty list, `maximum` returns `None`.
+
     The items in the list must be of a type that can be compared---for example, a `string` or `int`.
-   *) 
+   *)
   val maximum : 'comparable list -> 'comparable option
 
   (**
@@ -938,9 +1030,9 @@ module List : sig
     returned by `fcn`. This is a stable sort; if two items have the same value,
     they will appear in the same order that they appeared in the original list.
     (Same as `sort_by`.)
-    
+
     ### Example
-    
+
     ```reason
     sortBy(~f = (x) => {x * x}, [3, 2, 5, -2, 4]) == [2, -2, 3, 4, 5];
     ```
@@ -952,9 +1044,9 @@ module List : sig
     returned by `fcn`. This is a stable sort; if two items have the same value,
     they will appear in the same order that they appeared in the original list.
     (Same as `sortBy`.)
-    
+
     ### Example
-    
+
     ```ocaml
     sort_by ~f:(fun x -> x * x) [3; 2; 5; -2; 4] = [2; -2; 3; 4; 5]
     ```
@@ -965,14 +1057,14 @@ module List : sig
     `span ~f:predicate xs` (`span(~f=fcn, xs)` in ReasonML) splits the list `xs`
     into a tuple of two lists. The first list contains the first elements of `xs`
     that satisfy the predicate; the second list contains the remaining elements of `xs`.
-    
+
     ```ocaml
     let even x = x mod 2 = 0
     span ~f:even [4; 6; 8; 1; 2; 3] = ([4; 6; 8], [1; 2; 3])
     span ~f:even [1; 2; 3] = ([], [1; 2; 3])
     span ~f:even [20; 40; 60] = ([20; 40; 60], [])
     ```
-    
+
     ```reason
     let even = (x) => {x mod 2 == 0};
     span(~f=even, [4, 6, 8, 1, 2, 3]) == ([4, 6, 8], [1, 2, 3]);
@@ -985,46 +1077,46 @@ module List : sig
   (**
     `groupWhile(~f=fcn, xs)` produces a list of lists. Each sublist consists of
     consecutive elements of `xs` which belong to the same group according to `fcn`.
-    
+
     `fcn` takes two parameters and returns a `bool`: `true` if
     the values should be grouped together, `false` if not. (Same as `group_while`.)
-    
+
     ### Example
-    
+
     ```reason
     groupWhile(~f = (x, y) => {x mod 2 == y mod 2},
       [2, 4, 6, 5, 3, 1, 8, 7, 9]) == [[2, 4, 6], [5, 3, 1], [8], [7, 9]]
     ```
-  *) 
+  *)
   val groupWhile : f:('a -> 'a -> bool) -> 'a list -> 'a list list
 
   (**
     `group_while ~f:fcn xs` produces a list of lists. Each sublist consists of
     consecutive elements of `xs` which belong to the same group according to `fcn`.
-    
+
     `fcn` takes two parameters and returns a `bool`: `true` if
     the values should be grouped together, `false` if not. (Same as `groupWhile`.)
-    
+
     ### Example
-    
+
     ```ocaml
     groupWhile ~f:(fun x y -> x mod 2 == y mod 2)
       [2; 4; 6; 5; 3; 1; 8; 7; 9] = [[2; 4; 6]; [5; 3; 1]; [8]; [7; 9]]
     ```
-  *) 
+  *)
   val group_while : f:('a -> 'a -> bool) -> 'a list -> 'a list list
 
   (**
     `splitAt(~index=n, xs)` returns a tuple of two lists. The first list has the
     first `n` items of `xs`, the second has the remaining items of `xs`.
-    
+
     If `n` is less than zero or greater than the length of `xs`, `splitAt`
     returns two empty lists.
-    
+
     (Same as `split_at`.)
-    
+
     ### Example
-    
+
     ```reason
     splitAt(~index=3, [10, 11, 12, 13, 14]) == ([10, 11, 12], [13, 14])
     splitAt(~index=0, [10, 11, 12]) == ([], [10, 11, 12])
@@ -1037,14 +1129,14 @@ module List : sig
   (**
     `split_at ~index:n xs` returns a tuple of two lists. The first list has the
     first `n` items of `xs`, the second has the remaining items of `xs`.
-    
+
     If `n` is less than zero or greater than the length of `xs`, `split_at`
     returns two empty lists.
-    
+
     (Same as `splitAt`.)
-    
+
     ### Example
-    
+
     ```ocaml
     split_at ~index:3 [10; 11; 12; 13; 14] = ([10; 11; 12], [13; 14])
     split_at ~index:0 [10; 11; 12] = ([], [10; 11; 12])
@@ -1057,13 +1149,13 @@ module List : sig
 
   (**
     `insertAt(~index=n, ~value=v, xs)` returns a new list with the value `v` inserted
-    before position `n` in `xs`. If `n` is less than zero or greater than the length of `xs`, 
+    before position `n` in `xs`. If `n` is less than zero or greater than the length of `xs`,
     returns a list consisting only of the value `v`.
-    
+
     (Same as `insert_at`.)
-    
+
     ### Example:
-    
+
     ```reason
     insertAt(~index=2, ~value=999, [100, 101, 102, 103]) == [100, 101, 999, 102, 103]
     insertAt(~index=0, ~value=999, [100, 101, 102, 103]) == [999, 100 101, 102, 103]
@@ -1075,13 +1167,13 @@ module List : sig
 
   (**
     `insert_at ~index:n, ~value:v, xs` returns a new list with the value `v` inserted
-    before position `n` in `xs`. If `n` is less than zero or greater than the length of `xs`, 
+    before position `n` in `xs`. If `n` is less than zero or greater than the length of `xs`,
     returns a list consisting only of the value `v`.
-    
+
     (Same as `insertAt`.)
-    
+
     ### Example:
-    
+
     ```ocaml
     insert_at ~index:2 ~value:999 [100; 101; 102; 103] = [100; 101; 999; 102; 103]
     insert_at ~index:0 ~value:999 [100; 101; 102; 103] = [999; 100; 101; 102; 103]
@@ -1097,11 +1189,11 @@ module List : sig
     The first element of the tuple is the list of all the elements at the
     beginning of `xs` that  do _not_ satisfy the `predicate` function.
     The second element of the tuple is the list of the remaining items in `xs`.
-    
+
     (Same as `split_when`.)
-    
+
     ### Example
-    
+
     ```reason
     let even = (x) => {x mod 2 == 0};
     splitWhen(~f = even, [5, 1, 2, 6, 3]) == ([5, 1], [2, 6, 3]);
@@ -1118,11 +1210,11 @@ module List : sig
     The first element of the tuple is the list of all the elements at the
     beginning of `xs` that  do _not_ satisfy the `predicate` function.
     The second element of the tuple is the list of the remaining items in `xs`.
-    
+
     (Same as `splitWhen`.)
-    
+
     ### Example
-    
+
     ```reason
     let even x = (x mod 2 = 0)
     split_when ~f:even [5; 1; 2; 6; 3] = ([5; 1], [2; 6; 3])
@@ -1138,14 +1230,14 @@ module List : sig
     `intersperse separator xs` (`intersperse(separator, xs)` in ReasonML)
     inserts `separator`  between all the elements in `xs`. If `xs` is empty,
     `intersperse` returns the empty list.
-    
+
     ### Example
-    
+
     ```ocaml
     intersperse "/" ["a"; "b"; "c"] = ["a"; "/"; "b"; "/"; "c"]
     intersperse "?" [] = []
     ```
-    
+
     ```reason
     intersperse("/", ["a", "b", "c"]) == ["a", "/", "b", "/", "c"]
     intersperse("?", [] == [])
@@ -1157,7 +1249,7 @@ module List : sig
     `initialize n f` (`initialize(n, f)` in ReasonML) creates a list with values
     `[f 0; f 1; ...f (n - 1)]` (`[f(0), f(1),...f(n - 1)]` in ReasonML. Returns
     the empty list if given a negative value for `n`.
-    
+
     ### Example
     ```ocaml
     let cube_plus_one x = ((float_of_int x) +. 1.0) ** 3.0
@@ -1165,7 +1257,7 @@ module List : sig
     initialize 0 cube_plus_ones = []
     initialize (-2) cube_plus_one = []
     ```
-    
+
     ```reason
     let cube_plus_one = (x) => {(float_of_int(x) +. 1.0) ** 3.0};
     initialize(3, cube_plus_one) == [1.0, 8.0, 27.0];
@@ -1180,20 +1272,20 @@ module List : sig
     The `compareFcn` function takes two list items and returns a value less than zero if the first item
     compares less than the second, zero if the items compare equal, and one if the first item compares
     greater than the second.
-    
+
     This is a stable sort; items with equivalent values according to the `compareFcn`
     appear in the sorted list in the same order as they appeared in the original list.
 
     (Same as `sort_with`)
-    
+
     ```reason
     let cmp_mod12 = (a, b) => {
       (a mod 12) - (b mod 12)
     };
-    
-    sortWith(cmp_mod12, [15, 3, 22, 10, 16]) == [3, 15, 10, 22, 10] 
+
+    sortWith(cmp_mod12, [15, 3, 22, 10, 16]) == [3, 15, 10, 22, 10]
   *)
-  
+
   val sortWith : ('a -> 'a -> int) -> 'a list -> 'a list
 
   (**
@@ -1201,17 +1293,17 @@ module List : sig
     The `compareFcn` function takes two list items and returns a value less than zero if the first item
     compares less than the second, zero if the items compare equal, and one if the first item compares
     greater than the second.
-    
+
     This is a stable sort; items with equivalent values according to the `compareFcn`
     appear in the sorted list in the same order as they appeared in the original list.
-    
+
     (Same as `sortWith`)
-    
+
     ```ocaml
     let cmp_mod12 a b = (
       (a mod 12) - (b mod 12)
     )
-    
+
     sortWith cmp_mod12 [15; 3; 22; 10; 16] == [3; 15; 10; 22; 10]
     ```
   *)
@@ -1222,15 +1314,15 @@ module List : sig
     to each element in `xs`. The function you provide must return `unit`, and the
     `iter` call itself also returns `unit`. You use `iter` when you want to process
     a list only for side effects.
-    
+
     ### Example
-    
+
     The following code will print the items in the list to the console.
-    
+
     ```ocaml
     let _ = iter ~f:Js.log ["a"; "b"; "c"]
     ```
-    
+
     ```reason
     iter(~f=Js.log, ["a", "b", "c"]);
     ```
@@ -1315,7 +1407,7 @@ module Char : sig
   val fromCode : int -> char option
 
   val from_code : int -> char option
-  
+
   val toString : char -> string
 
   val to_string : char -> string
@@ -1365,6 +1457,18 @@ module Char : sig
   val is_whitespace : char -> bool
 end
 
+module Int : sig
+  val negate : int -> int
+
+  val isEven : int -> bool
+
+  val is_even : int -> bool
+
+  val isOdd : int -> bool
+
+  val is_odd : int -> bool
+end
+
 module Tuple2 : sig
   val create : 'a -> 'b -> 'a * 'b
 
@@ -1390,7 +1494,7 @@ module Tuple2 : sig
 
   val swap : ('a * 'b) -> ('b * 'a)
 
-  val curry : (('a * 'b) -> 'c) -> 'a -> 'b -> 'c 
+  val curry : (('a * 'b) -> 'c) -> 'a -> 'b -> 'c
 
   val uncurry : ('a -> 'b -> 'c) -> ('a * 'b) -> 'c
 
@@ -1405,7 +1509,7 @@ module Tuple3 : sig
   val first : ('a * 'b * 'c) -> 'a
 
   val second : ('a * 'b * 'c) -> 'b
-  
+
   val third : ('a * 'b * 'c) -> 'c
 
   val init : ('a * 'b * 'c) -> ('a * 'b)
@@ -1433,7 +1537,7 @@ module Tuple3 : sig
   val map_all : f:('a -> 'b) -> ('a * 'a * 'a) -> ('b * 'b * 'b)
 
   val rotateLeft : ('a * 'b * 'c) -> ('b * 'c * 'a)
-  
+
   val rotate_left : ('a * 'b * 'c) -> ('b * 'c * 'a)
 
   val rotateRight : ('a * 'b * 'c) -> ('c * 'a * 'b)
@@ -1443,7 +1547,7 @@ module Tuple3 : sig
   val curry : (('a * 'b * 'c) -> 'd) -> 'a -> 'b -> 'c -> 'd
 
   val uncurry : ('a -> 'b -> 'c -> 'd) -> ('a * 'b * 'c) -> 'd
-  
+
   val toList : ('a * 'a * 'a) -> 'a list
 
   val to_list : ('a * 'a * 'a) -> 'a list
@@ -1505,7 +1609,7 @@ module String : sig
   val contains : substring:string -> string -> bool
 
   val repeat : count:int -> string -> string
-  
+
   val reverse : string -> string
 
   val fromList : char list -> string

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -106,7 +106,7 @@ module Array = struct
     in    
     
     if sliceFrom >= sliceTo then empty else (
-      Array.init (sliceTo - sliceFrom) (fun i -> array.(i + sliceFrom))
+      Base.Array.init (sliceTo - sliceFrom) ~f:(fun i -> array.(i + sliceFrom))
     )
 
   let foldLeft ~(f : 'a -> 'b -> 'b) ~(initial : 'b) (a : 'a array) : 'b =

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -80,8 +80,6 @@ module Array = struct
 
   let concatenate  (al : 'a array array) : 'a array = Base.Array.concat (Base.Array.to_list al)
 
-  let flatten = concatenate
-
   let intersperse ~sep array = 
     Base.Array.init (max 0 (Array.length array * 2 - 1)) ~f:(fun i -> 
       if i mod 2 <> 0 then sep else array.(i / 2)

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -6,6 +6,133 @@ let ( << ) (f1 : 'b -> 'c) (f2 : 'a -> 'b) : 'a -> 'c = fun x -> x |> f2 |> f1
 
 let identity (value : 'a) : 'a = value
 
+module Array = struct
+  let empty : 'a array = [||]
+
+  let singleton (a : 'a) : 'a array = [|a|]
+
+  let length (a : 'a array) : int = Base.Array.length a
+
+  let isEmpty (a : 'a array) : bool = length a = 0
+
+  let is_empty = isEmpty
+
+  let initialize ~(length : int) ~(f : int -> 'a) = 
+    if length <= 0 then empty else Base.Array.init length ~f
+  
+  let repeat ~(length : int) (e : 'a) : 'a array = 
+    if length <= 0 then empty else Base.Array.init length ~f:(fun _ -> e)
+
+  let range ?(from = 0) (to_ : int) : int array =
+    Base.Array.init (max 0 (to_ - from)) ~f:(fun i -> i + from)
+
+  let fromList (l: 'a list) : 'a array = Base.List.to_array l
+
+  let from_list = fromList
+
+  let toList (a: 'a array) : 'a list = Base.Array.to_list a
+
+  let to_list = toList
+
+  let toIndexedList xs = 
+    Base.Array.fold_right xs ~init:(length xs - 1, []) ~f:(fun x (i, acc) -> 
+      (i - 1, ((i, x) :: acc)))
+    |> Base.snd
+  
+  let to_indexed_list = toIndexedList
+
+  let get ~index a = 
+    if index >= 0 && index < length a then Some (Base.Array.get a index) else None
+
+  let set ~index ~value a = Base.Array.set a index value
+
+  let sum (a : int array) : int = Base.Array.fold a ~init:0 ~f:( + )
+
+  let floatSum (a : float array) : float = Base.Array.fold a ~init:0.0 ~f:( +. )
+
+  let float_sum = floatSum
+
+  let filter ~(f : 'a -> bool) (a : 'a array) : 'a array = Base.Array.filter a ~f
+
+  let map ~(f : 'a -> 'b) (a : 'a array) : 'b array = Base.Array.map a ~f
+
+  let mapWithIndex  ~(f : 'int -> 'a -> 'b) (a : 'a array) : 'b array = Base.Array.mapi a ~f
+  
+  let map_with_index = mapWithIndex
+  
+  let mapi = mapWithIndex 
+
+  let map2 ~(f : 'a -> 'b -> 'c) (a : 'a array) (b : 'b array) : 'c array =
+    let minLength = min (length a) (length b) in
+    Base.Array.init minLength ~f:(fun i -> f a.(i) b.(i))
+
+  let map3 ~(f : 'a -> 'b -> 'c -> 'd) (arrayA : 'a array) (arrayB : 'b array) (arrayC : 'c array) : 'd array =
+    let minLength : int = Base.Array.fold ~f:Base.min ~init:(length arrayA) [|length arrayB; length arrayC|] in
+    Base.Array.init minLength ~f:(fun i -> f arrayA.(i) arrayB.(i) arrayC.(i))
+
+  let flatMap ~f a = Base.Array.concat_map a ~f
+
+  let flat_map = flatMap
+
+  let find ~(f : 'a -> bool) (a : 'a array) : 'a option = Base.Array.find a ~f
+
+  let append (a : 'a array) (a' : 'a array)  : 'a array = Base.Array.append a a'
+
+  let concatenate  (al : 'a array array) : 'a array = Base.Array.concat (Base.Array.to_list al)
+
+  let flatten = concatenate
+
+  let intersperse ~sep array = 
+    Base.Array.init (max 0 (Array.length array * 2 - 1)) ~f:(fun i -> 
+      if i mod 2 <> 0 then sep else array.(i / 2)
+    )
+
+  let any ~(f : 'a -> bool) (a : 'a array) : bool = Base.Array.exists ~f a
+
+  let all ~(f : 'a -> bool) (a : 'a array) : bool = Base.Array.for_all ~f a
+
+  let slice ~from ?to_ array =
+    let defaultTo = match to_ with 
+      | None -> length array
+      | Some i -> i
+    in
+    let sliceFrom = 
+      if from >= 0 then min (length array) from 
+      else max 0 (min (length array) (length array + from))
+    in    
+    let sliceTo = 
+      if defaultTo >= 0 then min (length array) defaultTo 
+      else max 0 (min (length array) (length array + defaultTo))
+    in    
+    
+    if sliceFrom >= sliceTo then empty else (
+      Array.init (sliceTo - sliceFrom) (fun i -> array.(i + sliceFrom))
+    )
+
+  let foldLeft ~(f : 'a -> 'b -> 'b) ~(initial : 'b) (a : 'a array) : 'b =
+    Base.Array.fold ~f:(fun b a -> f a b) ~init:initial a
+
+  let fold_left = foldLeft
+  
+  let foldRight ~(f : 'a -> 'b -> 'b) ~(initial : 'b) (a : 'a array) : 'b =
+    Base.Array.fold_right ~f ~init:initial a
+
+  let fold_right = foldRight
+
+  let reverse (a : 'a array) : 'a array = 
+    let copy = Base.Array.copy a in 
+    Base.Array.rev_inplace copy;
+    copy
+
+  let reverseInPlace (a : 'a array) = Base.Array.rev_inplace a
+
+  let reverse_in_place = reverseInPlace
+
+  let forEach ~(f : 'a -> unit) (a : 'a array) : unit = Base.Array.iter a ~f
+
+  let for_each = forEach
+end
+
 module Tuple2 = struct
   let create a b = (a, b)
 
@@ -562,6 +689,18 @@ module Char = struct
   let isWhitespace = Base.Char.is_whitespace
   
   let is_whitespace = isWhitespace
+end
+
+module Int = struct
+  let negate = (~-)
+
+  let isEven n = n mod 2 = 0
+
+  let is_even = isEven
+
+  let isOdd n = n mod 2 != 0
+
+  let is_odd = isOdd
 end
 
 module String = struct

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -6,6 +6,312 @@ val ( << ) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
 
 val identity : 'a -> 'a
 
+module Array : sig
+  (** A mutable vector of elements which must have the same type with O(1) {!get} and {!set} operations.
+
+   You can create an [array] in OCaml with the [[|1; 2; 3|]] syntax. *)
+
+  val empty : 'a array
+  (** An empty array.
+
+    {[Array.empty = [||]]}
+
+    {[Array.length Array.empty = 0]} *)
+
+  val singleton : 'a -> 'a array
+  (** Create an array with only one element.
+
+    {[Array.singleton 1234 = [|1234|]]}
+
+    {[Array.singleton "hi" = [|"hi"|]]} *)
+  
+  val length : 'a array -> int
+  (** Return the length of an array.
+
+    {[Array.length [|1; 2, 3|] = 3]}  
+
+    {[Array.length [||] = 0]} *)
+
+  val isEmpty : 'a array -> bool
+  (** Determine if an array is empty.
+
+    {[Array.isEmpty Array.empty = true]}
+
+    {[Array.isEmpty [||] = true]} 
+
+    {[Array.isEmpty [|1; 2; 3|] = false]} *)
+
+  val is_empty : 'a array -> bool  
+
+  val initialize : length:int -> f:(int -> 'a) -> 'a array
+  (** Initialize an array. [Array.initialize ~length:n ~f] creates an array of length [n] with
+    the element at index [i] initialized to the result of [(f i)].
+
+    {[Array.initialize ~length:4 ~f:identity = [|0; 1; 2; 3|]]}
+
+    {[Array.initialize ~length:4 ~f:(fun n -> n * n) = [|0; 1; 4; 9|]]} *)
+
+  val repeat : length:int -> 'a -> 'a array
+  (** Creates an array of length [length] with the value [x] populated at each index. 
+
+    {[repeat ~length:5 'a' = [|'a'; 'a'; 'a'; 'a'; 'a'|]]}
+
+    {[repeat ~length:0 7 = [||]]} 
+
+    {[repeat ~length:(-1) "Why?" = [||]]} *)
+
+  val range : ?from:int -> int -> int array
+  (** Creates an array containing all of the integers from [from] if it is provided or [0] if not, up to but not including [to] 
+  
+    {[Array.range 5 = [|0; 1; 2; 3; 4|] ]}
+
+    {[Array.range ~from: 2 5 = [|2; 3; 4|] ]}
+
+    {[Array.range ~from:(-2) 3 = [|-2; -1; 0; 1; 2|] ]} *)
+
+  val fromList : 'a list -> 'a array
+  (** Create an array from a {!List}. 
+
+    {[Array.fromList [1;2;3] = [|1;2;3|]]} *)
+
+  val from_list : 'a list -> 'a array
+
+  val toList : 'a array -> 'a list
+  (** Create a {!List} of elements from an array.
+
+    {[Array.toList [|1;2;3|] = [1;2;3]]}
+
+    {[Array.toList (Array.fromList [3; 5; 8]) = [3; 5; 8]]} *)
+
+  val to_list : 'a array -> 'a list
+
+  val toIndexedList : 'a array -> (int * 'a) list
+  (**  Create an indexed {!List} from an array. Each element of the array will be paired with its index as a {!Tuple2}.
+
+    {[Array.toIndexedList [|"cat"; "dog"|] = [(0, "cat"); (1, "dog")]]} *)
+
+  val to_indexed_list : 'a array -> (int * 'a) list
+
+  val get : index:int -> 'a array -> 'a option
+  (** [Array.get ~index:n a] returns, as an {!Option}, the element at index number [n] of array [a].
+
+    The first element has index number 0.
+
+    The last element has index number [Array.length a - 1].
+
+    Returns [None] if [n] is outside the range [0] to [(Array.length a - 1)].
+
+    You can also write [a.(n)] instead of [Array.get a n] but this raises [Invalid_argument "index out of bounds"] for index outside of the range of the array.
+
+    {[Array.get ~index:2 [|"cat"; "dog"; "eel"|] = Some "eel"]}
+
+    {[Array.get ~index:5 [|0; 1; 2|] = None]}
+
+    {[Array.get ~index:0 [||] = None]} *)
+
+  val set : index:int -> value:'a -> 'a array -> unit
+  (** [Array.set a ~index:n ~value:x] modifies array [a] in place, replacing the element at index number [n] with [x].
+
+    You can also write [a.(n) <- x] instead of [Array.set a ~index:n ~value:x].
+
+    Raises [Invalid_argument "index out of bounds"] if [n] is outside the range [0] to [Array.length a - 1]. 
+    
+    {[let setZero = Array.set ~value:0 in
+let numbers = [|1;2;3|] in
+  
+setZero numbers ~index:2;
+setZero numbers ~index:1;
+
+numbers = [|1;0;0|]]}
+
+    {[let setZerothElement = Array.set ~index:0 in
+let animals = [|"ant"; "bat"; "cat"|] in
+
+setZerothElement animals ~value:"antelope";
+
+animals = [|"antelope"; "bat"; "cat"|]]} *)
+
+  val sum : int array -> int
+  (** Get the total of adding all of the integers in an array. 
+
+    {[Array.sum [|1; 2; 3|] = 6]} *)
+
+  val floatSum : float array -> float
+  (** Get the total of adding all of the floating point numbers in an array. 
+
+    {[Array.floatSum [|1.0; 2.0; 3.0|] = 6.0]} *)
+
+  val float_sum : float array -> float
+
+  val filter : f:('a -> bool) -> 'a array -> 'a array
+  (** Keep elements that [f] returns [true] for.
+
+    {[Array.filter ~f:Int.isEven [|1; 2; 3; 4; 5; 6|] = [|2; 4; 6|]]} *)
+
+  val map : f:('a -> 'b) -> 'a array -> 'b array
+  (** Create a new array which is the result of applying a function [f] to every element.
+
+    {[Array.map ~f:sqrt [|1.0; 4.0; 9.0|] = [|1.0; 2.0; 3.0|]]} *)
+
+  val mapWithIndex : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+  (** Apply a function [f] to every element with its index as the first argument.
+
+   {[Array.mapWithIndex ~f:( * ) [|5; 5; 5|] = [|0; 5; 10|]]} *)
+
+  val map_with_index : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+
+  val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+
+  val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+  (** Combine two arrays, using [f] to combine each pair of elements.
+    If one array is longer, the extra elements are dropped.
+
+    {[let totals (xs : int array) (ys : int array) : int array =
+Array.map2 ~f:(+) xs ys in
+
+totals [|1;2;3|] [|4;5;6|] = [|5;7;9|]
+  
+Array.map2 
+  ~f:Tuple2.create 
+  [|"alice"; "bob"; "chuck"|] 
+  [|2; 5; 7; 8|] = 
+    [|("alice",2); ("bob",5); ("chuck",7)|] ]} *)
+
+  val map3 : f:('a -> 'b -> 'c -> 'd) -> 'a array -> 'b array -> 'c array -> 'd array
+  (** Combine three arrays, using [f] to combine each {!Tuple3} of elements.
+    If one array is longer, the extra elements are dropped.
+
+    {[ 
+  Array.map3 
+    ~f:Tuple3.create 
+    [|"alice"; "bob"; "chuck"|] 
+    [|2; 5; 7; 8;|] 
+    [|true; false; true; false|] = 
+      [|("alice", 2, true); ("bob", 5, false); ("chuck", 7, true)|]
+    ]} *)
+
+  val flatMap : f:('a -> 'a array) -> 'a array -> 'a array
+  (** Apply a function [f] onto an array and flatten the resulting array of arrays.
+
+    {[Array.flatMap ~f xs = Array.map ~f xs |> Array.flatten]} 
+    
+    {[Array.flatMap ~f:(fun n -> [|n; n|]) [|1; 2; 3|] = [|1; 1; 2; 2; 3; 3|]]} *)
+
+  val flat_map : f:('a -> 'a array) -> 'a array -> 'a array
+
+  val find : f:('a -> bool) -> 'a array -> 'a option
+  (** Returns as an option the first element for which f evaluates to true. If [f] doesn't return [true] for any of the elements [find] will return [None] 
+    {[Array.find ~f:Int.isEven [|1; 3; 4; 8;|] = Some 4]}
+
+    {[Array.find ~f:Int.isOdd [|0; 2; 4; 8;|] = None]}
+
+    {[Array.find ~f:Int.isEven [||] = None]} *)
+
+  val any : f:('a -> bool) -> 'a array -> bool
+  (**  Determine if [f] returns true for [any] values in an array.
+
+    {[Array.any ~f:isEven [|2;3|] = true]}
+
+    {[Array.any ~f:isEven [|1;3|] = false]}
+
+    {[Array.any ~f:isEven [||] = false]} *)
+
+  val all : f:('a -> bool) -> 'a array -> bool
+  (** Determine if [f] returns true for [all] values in an array.
+
+    {[Array.all ~f:Int.isEven [|2;4|] = true]}
+
+    {[Array.all ~f:Int.isEven [|2;3|] = false]}
+
+    {[Array.all ~f:Int.isEven [||] = true]} *)
+
+  val append : 'a array -> 'a array -> 'a array
+  (** Creates a new array which is the result of appending the second array onto the end of the first.
+
+    {[let fortyTwos = Array.repeat ~length:2 42 in 
+let eightyOnes = Array.repeat ~length:3 81 in
+Array.append fourtyTwos eightyOnes = [|42; 42; 81; 81; 81|];]} *)
+
+  val concatenate : 'a array array -> 'a array
+  (** Concatenate an array of arrays into a single array:
+
+    {[Array.concatenate [|[|1; 2|]; [|3|]; [|4; 5|]|] = [|1; 2; 3; 4; 5|]]} *)
+
+  val flatten : 'a array array -> 'a array  
+  (** An alias for {!Array.concatenate} *)
+
+  val intersperse : sep : 'a -> 'a array -> 'a array
+  (** Places [sep] between all elements of the given array.
+
+    {[Array.intersperse ~sep:"on" [|"turtles"; "turtles"; "turtles"|] = [|"turtles"; "on"; "turtles"; "on"; "turtles"|]]}
+
+    {[Array.intersperse ~sep:0 [||] = [||]]} *)
+
+  val slice : from : int -> ?to_: int -> 'a array -> 'a array
+  (** Get a sub-section of an array. [from] is a zero-based index where we will start our slice. 
+    The [to_] is a zero-based index that indicates the end of the slice. 
+
+    The slice extracts up to but not including [to_].
+
+    {[Array.slice ~from:0  ~to_:3 [|0; 1; 2; 3; 4|] = [|0; 1; 2|]]}
+
+    {[Array.slice ~from:1  ~to_:4 [|0; 1; 2; 3; 4|] = [|1; 2; 3|]]}
+
+    {[Array.slice ~from:5  ~to_:3 [|0; 1; 2; 3; 4|] = [||]]}
+
+    Both the [from] and [to_] indexes can be negative, indicating an offset from the end of the array.
+
+    {[Array.slice  ~from:1 ~to_:(-1) [|0; 1; 2; 3; 4|] = [|1; 2; 3|]]}
+
+    {[Array.slice ~from:(-2)  ~to_:5 [|0; 1; 2; 3; 4|] = [|3; 4|]]}
+  
+    {[Array.slice ~from:(-2)  ~to_:(-1) [|0; 1; 2; 3; 4|] = [|3|]]} *)
+
+  val foldLeft : f:('a -> 'b -> 'b)  -> initial:'b -> 'a array -> 'b
+  (** Reduces collection to a value which is the accumulated result of running each element in the array through [f], 
+      where each successive invocation is supplied the return value of the previous. 
+    
+    Read [foldLeft] as 'fold from the left'. 
+
+    {[Array.foldLeft ~f:( * ) ~initial:1 (Array.repeat ~length:4 7) = 2401]}
+    
+    {[Array.foldLeft ~f:((fun element list -> element :: list)) ~initial:[] [|1; 2; 3|] = [3; 2; 1]]} *)
+
+  val fold_left : f:('a -> 'b -> 'b)  -> initial:'b -> 'a array -> 'b
+
+  val foldRight : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+  (** This method is like [foldLeft] except that it iterates over the elements of the array from right to left.
+
+    {[Array.foldRight ~f:(+) ~initial:0 (Array.repeat ~length:3 5) = 15]}
+
+    {[Array.foldRight ~f:(fun element list -> element :: list) ~initial:[] [|1; 2; 3|] = [1; 2; 3]]} *)
+
+  val fold_right : f:('a -> 'b -> 'b) -> initial:'b -> 'a array -> 'b
+
+  val reverse : 'a array -> 'a array
+  (** Create a new reversed array leaving the original untouched 
+  
+  {[let numbers = [|1; 2; 3|] in
+Array.reverse numbers = [|3; 2; 1|];
+numbers = [|1; 2; 3|]; ]} *)
+
+  val reverseInPlace : 'a array -> unit
+  (** Reverses array so that the first element becomes the last, the second element becomes the second to last, and so on. 
+  
+  {[let numbers = [|1; 2; 3|] in
+Array.reverseInPlace numbers;
+numbers = [|3; 2; 1|]]} *)
+
+  val reverse_in_place : 'a array -> unit
+
+  val forEach : f:('a -> unit) -> 'a array -> unit
+  (** Iterates over the elements of invokes [f] for each element. 
+
+    {[Array.forEach [|1; 2; 3|] ~f:(fun int -> print (Int.toString int))]} *)
+
+  val for_each : f:('a -> unit) -> 'a array -> unit
+end
+
 module List : sig
   val flatten : 'a list list -> 'a list
 
@@ -421,6 +727,36 @@ module Char : sig
     [isWhitespace 'b' = false] *)
   
   val is_whitespace : char -> bool
+end
+
+module Int : sig
+  val negate : int -> int
+  (**
+    [Int.negate 8 = (-8)]
+
+    [Int.negate (-7) = 7]
+
+    [Int.negate 0 = 0] *)
+
+  val isEven : int -> bool
+  (**
+    [Int.isEven 8 = true]
+
+    [Int.isEven 7 = false]
+
+    [Int.isEven 0 = true] *)
+
+  val is_even : int -> bool
+
+  val isOdd : int -> bool
+    (**
+    [Int.isOdd 7 = true]
+
+    [Int.isOdd 8 = false]
+
+    [Int.isOdd 0 = false] *)
+
+  val is_odd : int -> bool
 end
 
 module Tuple2 : sig

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -237,9 +237,6 @@ Array.append fourtyTwos eightyOnes = [|42; 42; 81; 81; 81|];]} *)
 
     {[Array.concatenate [|[|1; 2|]; [|3|]; [|4; 5|]|] = [|1; 2; 3; 4; 5|]]} *)
 
-  val flatten : 'a array array -> 'a array  
-  (** An alias for {!Array.concatenate} *)
-
   val intersperse : sep : 'a -> 'a array -> 'a array
   (** Places [sep] between all elements of the given array.
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -1,6 +1,227 @@
 open Tablecloth
 module AT = Alcotest
 
+let trio a b c = 
+  let eq (a1, b1, c1) (a2, b2, c2) = AT.equal a a1 a2 && AT.equal b b1 b2 && AT.equal c c1 c2 in
+  let pp ppf (x, y, z) = Fmt.pf ppf "@[<1>(@[%a@],@ @[%a@],@ @[%a@])@]" (AT.pp a) x (AT.pp b) y (AT.pp c) z in
+  AT.testable pp eq
+
+let t_Array () =
+  AT.check AT.int "empty - has length zero" Array.(empty |> length) 0;
+  AT.check (AT.array AT.int) "empty - equals the empty array literal" (Array.empty) [||];
+
+  AT.check (AT.array AT.int) "singleton - equals an array literal of the same value" (Array.singleton 1234) [|1234|];
+  AT.check (AT.int) "singleton - has length one" Array.(singleton 1 |> length) 1;
+
+  AT.check (AT.int) "length - equals an array literal of the same value" (Array.length [||]) 0;
+  AT.check (AT.int) "length - has length one" (Array.length [|'a'|]) 1;
+  AT.check (AT.int) "length - has length two" (Array.length [|"a"; "b"|]) 2;
+
+  AT.check AT.bool "isEmpty - returns true for empty array literals" (Array.isEmpty [||]) true;
+  AT.check AT.bool "isEmpty - returns false for literals with a non-zero number of elements" (Array.isEmpty [|1234|]) false;
+
+  AT.check (AT.list AT.int) "map2 empty lists" (List.map2 ~f:(+) [] []) [];
+  AT.check (AT.list AT.int) "map2 one element" (List.map2 ~f:(+) [1] [1]) [2];
+  AT.check (AT.list AT.int) "map2 two elements" (List.map2 ~f:(+) [1;2] [1;2]) [2;4];
+  AT.check (AT.array AT.int) "initialize - create empty array" (Array.initialize ~length:0 ~f:identity) [||];
+  AT.check (AT.array AT.int) "initialize - negative length gives an empty array" (Array.initialize ~length:(-1) ~f:identity) [||];
+  AT.check (AT.array AT.int) "initialize - create array with initialize" (Array.initialize ~length:3 ~f:identity) [|0;1;2|];
+
+  AT.check (AT.list AT.int) "indexedMap empty list" (List.indexedMap ~f:(fun i _ -> i) []) [];
+  AT.check (AT.list AT.int) "indexedMap one element" (List.indexedMap ~f:(fun i _ -> i) ['a']) [0];
+  AT.check (AT.list AT.int) "indexedMap two elements" (List.indexedMap ~f:(fun i _ -> i) ['a';'b']) [0;1];
+  AT.check (AT.array AT.int) "repeat - length zero creates an empty array" (Array.repeat 0 ~length:0) [||];
+  AT.check (AT.array AT.int) "repeat - negative length gives an empty array" (Array.repeat ~length:(-1) 0) [||];
+  AT.check (AT.array AT.int) "repeat - create array of ints" (Array.repeat 0 ~length:3) [|0;0;0|];
+  AT.check (AT.array AT.string) "repeat - create array strings" (Array.repeat "cat" ~length:3) [|"cat";"cat";"cat"|];
+
+  AT.check (AT.array AT.int) "range - returns an array of the integers from zero and upto but not including [to]" (Array.range 5) [|0; 1; 2; 3; 4|];
+  AT.check (AT.array AT.int) "range - returns an empty array when [to] is zero" (Array.range 0) [||];
+  AT.check (AT.array AT.int) "range - takes an optional [from] argument to start create empty array" (Array.range ~from:2 5) [|2; 3; 4|];
+  AT.check (AT.array AT.int) "range - returns an array of the integers from zero and upto but not including [to_]" (Array.range 5) [|0; 1; 2; 3; 4|];
+  AT.check (AT.array AT.int) "range - returns an array of the integers from zero and upto but not including [to_]" (Array.range 0) [||];
+  AT.check (AT.array AT.int) "range - takes an optional [from] argument to start create empty array" (Array.range ~from:2 5) [|2; 3; 4|];
+  AT.check (AT.array AT.int) "range - can start from negative values" (Array.range ~from:(-2) 3) [|-2; -1; 0; 1; 2|];
+  AT.check (AT.array AT.int) "range - returns an empty array when [from] > [to_]" (Array.range ~from:5 0) [||];
+  AT.check (AT.array AT.int) "range - can start from negative values" (Array.range ~from:(-2) 3) [|-2; -1; 0; 1; 2|];
+  AT.check (AT.array AT.int) "range - returns an empty array when [from] > [to_]" (Array.range ~from:5 0) [||];
+
+  AT.check (AT.list AT.int) "indexedMap empty list" (List.indexedMap ~f:(fun _ n -> n + 1) []) [];
+  AT.check (AT.list AT.int) "indexedMap one element" (List.indexedMap ~f:(fun _ n -> n + 1) [-1]) [0];
+  AT.check (AT.list AT.int) "indexedMap two elements" (List.indexedMap ~f:(fun _ n -> n + 1) [-1; 0]) [0;1];
+  AT.check (AT.array AT.int) "fromList - transforms a list into an array of the same elements" Array.(fromList [1;2;3]) [|1;2;3|];
+
+  AT.check (AT.list AT.int) "toList - transform an array into a list of the same elements" (Array.toList [|1;2;3|]) [1;2;3];
+
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition empty list" (List.partition ~f:(fun x -> x mod 2 = 0) []) ([], []);
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition one element" (List.partition ~f:(fun x -> x mod 2 = 0) [1]) ([], [1]);
+  AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition four elements" (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) ([2;4], [1;3]);
+  AT.check (AT.list (AT.pair AT.int AT.string)) "toIndexedList - returns an empty list for an empty array" (Array.toIndexedList [||]) [];
+  AT.check (AT.list (AT.pair AT.int AT.string)) "toIndexedList - transforms an array into a list of tuples" (Array.toIndexedList [|"cat"; "dog"|]) [(0, "cat"); (1, "dog")];
+
+  AT.check (AT.option AT.string) "get - returns Some for an in-bounds indexe" (Array.get ~index:2 [|"cat"; "dog"; "eel"|]) (Some "eel");
+  AT.check (AT.option AT.int) "get - returns None for an out of bounds index" (Array.get ~index:5 [|0; 1; 2|]) None;
+  AT.check (AT.option AT.int) "get - returns None for an empty array" (Array.get ~index:0 [||]) None;
+
+  AT.check 
+    (AT.array AT.int) 
+    "set - can be partially applied to set an element" 
+    (
+      let setZero = Array.set ~value:0 in
+      let numbers = [|1;2;3|] in
+      setZero numbers ~index:2;
+      setZero numbers ~index:1;
+      numbers 
+    )
+    [|1;0;0|];
+
+  AT.check 
+    (AT.array AT.string) 
+    "set - can be partially applied to set an index" 
+    (
+      let setZerothElement = Array.set ~index:0 in
+      let animals = [|"ant"; "bat"; "cat"|] in    
+      setZerothElement animals ~value:"antelope";    
+      animals
+    ) 
+    [|"antelope"; "bat"; "cat"|];
+
+  AT.check AT.int "sum - equals zero for an empty array" (Array.sum [||]) 0;
+  AT.check (AT.int) "sum - adds up the elements on an integer array" (Array.sum [|1;2;3|]) 6;
+
+  AT.check (AT.float 0.) "floatSum - equals zero for an empty array" (Array.floatSum [||]) 0.0;
+  AT.check (AT.float 0.) "floatSum - adds up the elements of a float array" (Array.floatSum [|1.2;2.3;3.4|]) 6.9;
+
+  AT.check (AT.array AT.int) "filter - keep elements that [f] returns [true] for" (Array.filter ~f:Int.isEven [|1; 2; 3; 4; 5; 6|]) [|2; 4; 6|];
+
+  AT.check (AT.array (AT.float 0.)) "map - Apply a function [f] to every element in an array" (Array.map ~f:sqrt [|1.0; 4.0; 9.0|]) [|1.0; 2.0; 3.0|];
+
+  AT.check (AT.array AT.int) "mapWithIndex - equals an array literal of the same value" (Array.mapWithIndex ~f:( * ) [|5; 5; 5|]) [|0; 5; 10|];
+
+  AT.check (AT.array AT.int) "map2 - works when the order of arguments to `f` is not important" (Array.map2 ~f:(+) [|1;2;3|] [|4;5;6|]) [|5;7;9|];
+
+  AT.check 
+    (AT.array (AT.pair AT.string AT.int)) 
+    "map2 - works when the order of `f` is important" 
+    (Array.map2 ~f:Tuple2.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8|]) 
+    [|("alice",2);("bob",5);("chuck",7)|];
+
+  AT.check 
+    (AT.array (trio AT.string AT.int AT.bool)) 
+    "map3" 
+    (Array.map3 ~f:Tuple3.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8;|] [|true; false; true; false|]) 
+    [|("alice", 2, true); ("bob", 5, false); ("chuck", 7, true)|];
+
+  AT.check (AT.array AT.int) "flatMap" (Array.flatMap ~f:(fun n -> [|n; n|]) [|1; 2; 3|]) [|1; 1; 2; 2; 3; 3|];
+
+  AT.check (AT.option AT.int) "find - returns the first element which `f` returns true for" (Array.find ~f:Int.isEven [|1; 3; 4; 8;|]) (Some 4);
+  AT.check (AT.option AT.int) "find - returns `None` if `f` returns false for all elements" (Array.find ~f:Int.isOdd [|0; 2; 4; 8;|]) None;
+  AT.check (AT.option AT.int) "find - returns `None` for an empty array" (Array.find ~f:Int.isEven [||]) None;
+
+  AT.check (AT.bool) "any - returns false for empty arrays" (Array.any [||] ~f:Int.isEven) false;
+  AT.check (AT.bool) "any - returns true if at least one of the elements of an array return true for [f]" (Array.any [|1;3;4;5;7|] ~f:Int.isEven) true;
+  AT.check (AT.bool) "any - returns false if all of the elements of an array return false for [f]" (Array.any [|1;3;5;7|] ~f:Int.isEven) false;
+
+  AT.check (AT.bool) "all - returns true for empty arrays" (Array.all ~f:Int.isEven [||]) true;
+  AT.check (AT.bool) "all - returns true if [f] returns true for all elements" (Array.all ~f:Int.isEven [|2;4|]) true;
+  AT.check (AT.bool) "all - returns false if a single element fails returns false for [f]" (Array.all ~f:Int.isEven [|2;3|]) false;
+
+  AT.check (AT.array AT.int) "append" (Array.append (Array.repeat ~length:2 42) (Array.repeat ~length:3 81)) [|42; 42; 81; 81; 81|];
+
+  AT.check (AT.array AT.int) "concatenate" (Array.concatenate [|[|1; 2|]; [|3|]; [|4; 5|]|]) [|1; 2; 3; 4; 5|];
+
+  AT.check 
+    (AT.array AT.string) 
+    "intersperse - equals an array literal of the same value" 
+    [|"turtles"; "on"; "turtles"; "on"; "turtles"|]
+    (Array.intersperse ~sep:"on" [|"turtles"; "turtles"; "turtles"|]);
+
+  AT.check (AT.array AT.int) "intersperse - equals an array literal of the same value" (Array.intersperse ~sep:0 [||]) [||];
+
+  (
+    let array = [|0; 1; 2; 3; 4|] in
+    let positiveArrayLengths = [Array.length array; Array.length array + 1; 1000] in
+    let negativeArrayLengths = List.map ~f:Int.negate positiveArrayLengths in
+
+    AT.check (AT.array AT.int) "slice - should work with a positive `from`" (Array.slice ~from:1 array) [|1; 2; 3; 4|];
+
+    AT.check (AT.array AT.int) "slice - should work with a negative `from`" (Array.slice ~from:(-1) array) [|4|];
+
+    Base.List.iter positiveArrayLengths ~f:(fun from -> 
+      AT.check (AT.array AT.int) "slice - should work when `from` >= `length`" (Array.slice ~from array) [||]
+    );
+
+    Base.List.iter negativeArrayLengths ~f:(fun from -> 
+      AT.check (AT.array AT.int) "slice - should work when `from` <= negative `length`"  (Array.slice ~from array) array
+    );
+
+    AT.check (AT.array AT.int) "slice - should work with a positive `to_`" (Array.slice ~from:0  ~to_:3 array) [|0; 1; 2|];
+
+    AT.check (AT.array AT.int) "slice - should work with a negative `to_`" (Array.slice  ~from:1 ~to_:(-1) array) [|1; 2; 3|];
+
+    Base.List.iter positiveArrayLengths ~f:(fun to_ ->
+      AT.check (AT.array AT.int) "slice - should work when `to_` >= length" ( Array.slice ~from:0  ~to_ array) array
+    );
+
+    Base.List.iter negativeArrayLengths ~f:(fun to_ ->
+      AT.check (AT.array AT.int) "slice - should work when `to_` <= negative `length`"  (Array.slice ~from:0  ~to_ array) [||]
+    );
+    
+    AT.check (AT.array AT.int) "slice - should work when both `from` and `to_` are negative and `from` < `to_`" (Array.slice ~from:(-2)  ~to_:(-1) array) [|3|];
+
+    AT.check (AT.array AT.int) "slice - works when `from` >= `to_`" (Array.slice ~from:(4)  ~to_:(3) array) [||];
+  );
+
+  AT.check (AT.string) "foldLeft - works for an empty array" (Array.foldLeft [||] ~f:(^) ~initial:"") "";
+  AT.check (AT.int) "foldLeft - works for an ascociative operator" (Array.foldLeft ~f:( * ) ~initial:1 (Array.repeat ~length:4 7)) 2401;
+  AT.check (AT.string) "foldLeft - works when the order of arguments to `f` is important" (Array.foldLeft [|"a";"b";"c"|] ~f:(^) ~initial:"") "cba";
+  AT.check (AT.list AT.int) "foldLeft - works when the order of arguments to `f` is important" (Array.foldLeft ~f:(fun element list -> element :: list) ~initial:[] [|1; 2; 3|]) [3; 2; 1];
+
+  AT.check (AT.string) "foldRight - works for empty arrays" (Array.foldRight [||] ~f:(^) ~initial:"") "";
+  AT.check (AT.int) "foldRight - works for an ascociative operator" (Array.foldRight ~f:(+) ~initial:0 (Array.repeat ~length:3 5)) 15;
+  AT.check (AT.string) "foldRight - works when the order of arguments to `f` is important" (Array.foldRight [|"a";"b";"c"|] ~f:(^) ~initial:"") "abc";
+  AT.check (AT.list AT.int) "foldRight - works when the order of arguments to `f` is important" (Array.foldRight ~f:(fun element list -> element :: list) ~initial:[] [|1; 2; 3|]) [1; 2; 3];
+
+  AT.check (AT.array AT.int) "reverse - empty array" (Array.reverse [||]) [||];
+  AT.check (AT.array AT.int) "reverse - two elements" (Array.reverse [|0;1|]) [|1;0|];
+  AT.check 
+    (AT.array AT.int) 
+    "reverse - leaves the original array untouched" 
+    (
+      let array = [|0; 1; 2; 3;|] in
+      let _reversedArray = Array.reverse array in
+      array
+    ) 
+    [|0; 1; 2; 3;|];
+
+  AT.check 
+    (AT.array AT.int) 
+    "reverseInPlace - alters an array in-place" 
+    (
+      let array = [|1;2;3|] in
+      Array.reverseInPlace array;
+      array
+    ) 
+    [|3;2;1|];
+
+  AT.check 
+    (AT.array AT.int) 
+    "forEach" (
+      let index = ref 0 in
+      let calledValues = [|0;0;0|] in
+    
+      Array.forEach [|1;2;3|] ~f:(fun value -> 
+        Array.set calledValues ~index:!index ~value;
+        index := !index + 1;
+      );
+      
+      calledValues
+    ) 
+    [|1;2;3|];
+  
+  ()
+
+
 let t_Char () =
   AT.check AT.int "toCode" (Char.toCode 'a') 97;
 
@@ -133,10 +354,7 @@ let t_Tuple2 () =
 
   ()
 
-let trio a b c = 
-  let eq (a1, b1, c1) (a2, b2, c2) = AT.equal a a1 a2 && AT.equal b b1 b2 && AT.equal c c1 c2 in
-  let pp ppf (x, y, z) = Fmt.pf ppf "@[<1>(@[%a@],@ @[%a@],@ @[%a@])@]" (AT.pp a) x (AT.pp b) y (AT.pp c) z in
-  AT.testable pp eq
+
 
 let t_Tuple3 () =
   AT.check (trio AT.int AT.int AT.int) "create" (Tuple3.create 3 4 5) (3, 4, 5);
@@ -174,6 +392,7 @@ let t_Tuple3 () =
   ()
 
 let suite = [
+  ("Array", `Quick, t_Array); 
   ("Char", `Quick, t_Char); 
   ("String", `Quick, t_String); 
   ("Tuple2", `Quick, t_Tuple2);


### PR DESCRIPTION
I started from @j-m-hoffmann 's pull request #14 and in an effort to have a more manageable PR I 
- removed a lot of the functions, so it is still quite incomplete compared to `List` or `Base` / `Belt` 
- Added tests and documentation for each of the functions

I also added a teeny Int module since it made writing the examples / tests easier.

This differs from Elms Array module in the following ways:
- The addition of the `singleton`, `range`, `map2`, `flatMap`, `set` `any`, `all`, `append`, `concatenate`, `flatten`, `intersperse`, `reverse`, `reverseInPlace` & `forEach` functions.
- The omission of `push`
- `indexedMap` -> `mapWithIndex`
- `foldl` -> `foldLeft` & `foldr` -> `foldRight`, additionally both functions have slightly different signatures
- `slice` uses a named and optional parameter