### PR TITLE
Change output from pp() in Result module.

### DIFF
--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -361,7 +361,7 @@ module Result = struct
         okf fmt ok ;
         Format.pp_print_string fmt ">"
     | Error err ->
-        Format.pp_print_string fmt "<ok: " ;
+        Format.pp_print_string fmt "<error: " ;
         errf fmt err ;
         Format.pp_print_string fmt ">"
 end

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -496,7 +496,7 @@ module Result = struct
         okf fmt ok ;
         Format.pp_print_string fmt ">"
     | Error err ->
-        Format.pp_print_string fmt "<ok: " ;
+        Format.pp_print_string fmt "<error: " ;
         errf fmt err ;
         Format.pp_print_string fmt ">"
 end


### PR DESCRIPTION
Currently, the `Result.pp()` function prints `<ok:` at the beginning of all values, whether they are `Ok x` or `Error err`. This change prints `<error:` at the beginning of an `Error` result.