### PR TITLE
Move foldr_values into values as helper function.

### DIFF
--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -393,14 +393,11 @@ module Option = struct
 
   let with_default = withDefault
 
-  let foldrValues (item : 'a option) (l: 'a list) : 'a list =
-    match item with None -> l | Some v -> v :: l
-
-
-  let foldr_values = foldrValues
-
+  
   let values (l : 'a option list) : 'a list =
-    List.foldr ~f:foldrValues ~init:[] l
+    let valuesHelper (item : 'a option) (l: 'a list) : 'a list =
+      match item with None -> l | Some v -> v :: l in
+    List.foldr ~f:valuesHelper ~init:[] l
 
 
   let toList (o : 'a option) : 'a list =

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -1546,10 +1546,6 @@ module Option : sig
 
   val with_default : default:'a -> 'a option -> 'a
 
-  val foldrValues : 'a option -> 'a list -> 'a list
-
-  val foldr_values : 'a option -> 'a list -> 'a list
-
   val values : 'a option list -> 'a list
 
   val toList : 'a option -> 'a list

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -415,14 +415,11 @@ module Option = struct
 
   let with_default = withDefault
 
-  let foldrValues (item : 'a option) (list : 'a list) : 'a list =
-    match item with None -> list | Some v -> v :: list
-
-
-  let foldr_values = foldrValues
-
+  
   let values (l : 'a option list) : 'a list =
-    List.foldr ~f:foldrValues ~init:[] l
+    let valuesHelper (item : 'a option) (list : 'a list) : 'a list =
+      match item with None -> list | Some v -> v :: list in
+    List.foldr ~f:valuesHelper ~init:[] l
 
 
   let toList (o : 'a option) : 'a list =

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -202,10 +202,6 @@ module Option : sig
 
   val with_default : default:'a -> 'a option -> 'a
 
-  val foldrValues : 'a option -> 'a list -> 'a list
-
-  val foldr_values : 'a option -> 'a list -> 'a list
-
   val values : 'a option list -> 'a list
 
   val toList : 'a option -> 'a list


### PR DESCRIPTION
Took `foldr_values` out of the `.mli` files, renamed it to `valuesHelper` and moved it inside the `values` function. (Did this in both native and BuckleScript.)