### PR TITLE
Add Task module

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -573,6 +573,7 @@ let () =
 
   describe "Task" (fun () ->
     let test = testAsync ~timeout:10 in
+
     test "perform/succeed" (fun cb ->
       Task.perform (Task.succeed 4) ~f:(fun a ->
         cb (expect a |> toEqual 4)
@@ -582,6 +583,22 @@ let () =
     test "attempt/fail" (fun cb ->
       Task.attempt (Task.fail 4) ~f:(fun res ->
         cb (expect res |> toEqual (Belt.Result.Error 4))
+      )
+    );
+
+    test "create" (fun cb ->
+      let task =
+        Task.create (fun complete ->
+          let _ =
+            Js.Global.setTimeout (fun () ->
+              complete (Belt.Result.Ok 4)
+            ) 0
+          in
+          ()
+        )
+      in
+      Task.perform task ~f:(fun a ->
+          cb (expect a |> toEqual 4)
       )
     );
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1115,6 +1115,10 @@ end
 module Task = struct
   type (+'x, +'a) t = unit -> ('x, 'a) Result.t Js.Promise.t
 
+  let create (f: (('x, 'a) Result.t -> unit) -> unit) : ('x, 'a) t =
+    fun () ->
+      Js.Promise.make (fun ~resolve ~reject:_ -> f (fun res -> (resolve res)[@bs ]))
+
   let succeed (a: 'a) : ('x, 'a) t = fun () -> (Js.Promise.resolve (Belt.Result.Ok a))
 
   let fail (x: 'x) : ('x, 'a) t = fun () -> (Js.Promise.resolve (Belt.Result.Error x))

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -2338,6 +2338,8 @@ module Task : sig
    *)
   type (+'x, +'a) t = unit -> ('x, 'a) Result.t Js.Promise.t
 
+  val create : ((('x, 'a) Result.t -> unit) -> unit) -> ('x, 'a) t
+
   val succeed : 'a -> ('x, 'a) t
 
   val fail : 'x -> ('x, 'a) t


### PR DESCRIPTION
Tablecloth is missing some sort of async monad primitive (like Task in
Elm, Promise in JavaScript, and Deferred in Jane Street land). This PR
adds a Task module to fill that gap.

API matches https://package.elm-lang.org/packages/elm/core/latest/Task
wherever possible while also keeping to ocaml-isms like the named
argument for ~f.

I've only implemented the bucklescript side for now, but I'd be happy to
do the native side as well if you'd be willing to merge something like
  this. The only caveat is Tablecloth would have to also depend on
  async_kernel to implement Task backed by Deferred, and even the async
  library itself to be able to actually execute the Deferred i.e. to
  implement perform and attempt.

Another option if you want to keep the native deps only on base is to
make this async part into a separate library.

I'll also improve the documentation if this is something you're open to
merging.