### PR TITLE
Remove regex modules, fixes #1

### DIFF
--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1091,19 +1091,3 @@ module IntDict = struct
     Map.merge dict1 dict2 f
 end
 
-module Regex = struct 
-  type t = Js.Re.t
-
-  type result = Js.Re.result
-
-  let regex s : Js.Re.t = Js.Re.fromStringWithFlags ~flags:"g" s
-
-  let contains ~(re : Js.Re.t) (s : string) : bool = Js.Re.test s re
-
-  let replace ~(re : Js.Re.t) ~(repl : string) (str : string) =
-    Js.String.replaceByRe re repl str
-
-
-  let matches ~(re : Js.Re.t) (s : string) : Js.Re.result option =
-    Js.Re.exec s re
-end

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -2305,16 +2305,3 @@ module IntDict : sig
     -> 'v3 t
 end
 
-module Regex : sig
-  type t = Js.Re.t
-
-  type result = Js.Re.result
-
-  val regex : string -> t
-
-  val contains : re:t -> string -> bool
-
-  val replace : re:t -> repl:string -> string -> string
-
-  val matches : re:t -> string -> result option
-end


### PR DESCRIPTION
As discussed in #1 , Regex doesn't have an equivalent on native and doesn't work without warnings as written in the latest bs-platform release.