### PR TITLE
Expand the Int and Float modules for 'native'

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -395,6 +395,427 @@ let () =
     );
   );
 
+  describe "Float" (fun () -> Float.(
+    test "zero" (fun () ->
+      expect zero |> toEqual 0.;
+    );
+
+    test "one" (fun () ->
+      expect one |> toEqual 1.;
+    );
+
+    test "nan" (fun () ->
+      expect (nan = nan) |> toEqual false;
+    );
+
+    test "infinity" (fun () ->
+      expect (infinity > 0.) |> toEqual true;
+    );
+
+    test "negativeInfinity" (fun () ->
+      expect (negativeInfinity < 0.) |> toEqual true;
+    );
+
+    describe "equals" (fun () ->
+      test "zero" (fun () ->
+        expect (0. = (-0.)) |> toBe true;
+      );
+    );
+
+    describe "add" (fun () ->
+      test "add" (fun () -> expect (add 3.14 3.14) |> toEqual 6.28);
+      test "+" (fun () -> expect (3.14 + 3.14) |> toEqual 6.28);
+    );
+
+    describe "subtract" (fun () ->
+      test "subtract" (fun () -> expect (subtract 4. 3.) |> toEqual 1.);
+      test "-" (fun () -> expect (4. - 3.) |> toEqual 1.);
+    );
+
+    describe "multiply" (fun () ->
+      test "multiply" (fun () -> expect (multiply 2. 7.) |> toEqual 14.);
+      test "*" (fun () -> expect (2. * 7.) |> toEqual 14.);
+    );
+
+    describe "divide" (fun () ->
+      test "divide" (fun () -> expect (divide 3.14 ~by:2.) |> toEqual 1.57);
+      test "divide by zero" (fun () -> expect (divide 3.14 ~by:0.) |> toEqual infinity);
+      test "divide by negative zero" (fun () -> expect (divide 3.14 ~by:(-0.)) |> toEqual negativeInfinity);
+
+      test "/" (fun () -> expect (3.14 / 2.) |> toEqual 1.57);
+    );
+
+    describe "power" (fun () ->
+      test "power" (fun () -> expect (power ~base:7. ~exponent:3.) |> toEqual 343.);
+      test "0 base" (fun () -> expect (power ~base:0. ~exponent:3.) |> toEqual 0.);
+      test "0 exponent" (fun () -> expect (power ~base:7. ~exponent:0.) |> toEqual 1.);
+      test "**" (fun () -> expect (7. ** 3.) |> toEqual 343.);
+    );
+
+    describe "negate" (fun () ->
+      test "positive number" (fun () -> expect (negate 8.) |> toEqual (-8.));
+      test "negative number" (fun () -> expect (negate (-7.)) |> toEqual 7.);
+      test "zero" (fun () -> expect (negate 0.) |> toEqual (-0.));
+      test "~-" (fun () -> expect (~- 7.) |> toEqual (-7.));
+    );
+
+    describe "absolute" (fun () ->
+      test "positive number" (fun () -> expect (absolute 8.) |> toEqual 8.);
+      test "negative number" (fun () -> expect (absolute (-7.)) |> toEqual 7.);
+      test "zero" (fun () -> expect (absolute 0.) |> toEqual 0.);
+    );
+
+    describe "maximum" (fun () ->
+      test "positive numbers" (fun () -> expect (maximum 7. 9.) |> toEqual 9.);
+      test "negative numbers" (fun () -> expect (maximum (-4.) (-1.)) |> toEqual (-1.));
+      test "nan" (fun () -> expect (maximum 7. nan) |> toEqual nan);
+      test "infinity" (fun () -> expect (maximum 7. infinity) |> toEqual infinity);
+      test "negativeInfinity" (fun () -> expect (maximum 7. negativeInfinity) |> toEqual 7.);
+    );
+
+    describe "minimum" (fun () ->
+      test "positive numbers" (fun () -> expect (minimum 7. 9.) |> toEqual 7.);
+      test "negative numbers" (fun () -> expect (minimum (-4.) (-1.)) |> toEqual (-4.));
+      test "nan" (fun () -> expect (minimum 7. nan) |> toEqual nan);
+      test "infinity" (fun () -> expect (minimum 7. infinity) |> toEqual 7.);
+      test "negativeInfinity" (fun () -> expect (minimum 7. negativeInfinity) |> toEqual negativeInfinity);
+    );
+
+    describe "clamp" (fun () ->
+      test "in range" (fun () -> expect (clamp ~lower:0. ~upper:8. 5.) |> toEqual 5.);
+      test "above range" (fun () -> expect (clamp ~lower:0. ~upper:8. 9.) |> toEqual 8.);
+      test "below range" (fun () -> expect (clamp ~lower:2. ~upper:8. 1.) |> toEqual 2.);
+      test "above negative range" (fun () -> expect (clamp ~lower:(-10.) ~upper:(-5.) 5.) |> toEqual (-5.));
+      test "below negative range" (fun () -> expect (clamp ~lower:(-10.) ~upper:(-5.) (-15.)) |> toEqual (-10.));
+      test "nan upper bound" (fun () -> expect (clamp ~lower:(-7.9) ~upper:nan (-6.6)) |> toEqual nan);
+      test "nan lower bound" (fun () -> expect (clamp ~lower:nan ~upper:0. (-6.6)) |> toEqual nan);
+      test "nan value" (fun () -> expect (clamp ~lower:2. ~upper:8. nan) |> toEqual nan);
+      test "invalid arguments" (fun () -> expect (fun () -> clamp ~lower:7. ~upper:1. 3.) |> toThrow);
+    );
+
+    describe "squareRoot" (fun () ->
+      test "whole numbers" (fun () -> expect (squareRoot 4.) |> toEqual 2.);
+      test "decimal numbers" (fun () -> expect (squareRoot 20.25) |> toEqual 4.5);
+      test "negative number" (fun () -> expect (squareRoot (-1.)) |> toEqual nan);
+    );
+
+    describe "log" (fun () ->
+      test "base 10" (fun () -> expect (log ~base:10. 100.) |> toEqual 2.);
+      test "base 2" (fun () -> expect (log ~base:2. 256.) |> toEqual 8.);
+      test "of zero" (fun () -> expect (log ~base:10. 0.) |> toEqual negativeInfinity);
+    );
+
+    describe "isNaN" (fun () ->
+      test "nan" (fun () -> expect (isNaN nan) |> toEqual true);
+      test "non-nan" (fun () -> expect (isNaN 91.4) |> toEqual false);
+    );
+
+    describe "isFinite" (fun () ->
+      test "infinity" (fun () -> expect (isFinite infinity) |> toEqual false);
+      test "negative infinity" (fun () -> expect (isFinite negativeInfinity) |> toEqual false);
+      test "NaN" (fun () -> expect (isFinite nan) |> toEqual false);
+      testAll "regular numbers" [-5.; -0.314; 0.; 3.14] (fun (n) -> expect (isFinite n) |> toEqual true);
+    );
+
+    describe "isInfinite" (fun () ->
+      test "infinity" (fun () -> expect (isInfinite infinity) |> toEqual true);
+      test "negative infinity" (fun () -> expect (isInfinite negativeInfinity) |> toEqual true);
+      test "NaN" (fun () -> expect (isInfinite nan) |> toEqual false);
+      testAll "regular numbers" [-5.; -0.314; 0.; 3.14] (fun (n) -> expect (isInfinite n) |> toEqual false);
+    );
+
+    describe "inRange" (fun () ->
+      test "in range" (fun () -> expect (inRange ~lower:2. ~upper:4. 3.) |> toEqual true);
+      test "above range" (fun () -> expect (inRange ~lower:2. ~upper:4. 8.) |> toEqual false);
+      test "below range" (fun () -> expect (inRange ~lower:2. ~upper:4. 1.) |> toEqual false);
+      test "equal to ~upper" (fun () -> expect (inRange ~lower:1. ~upper:2. 2.) |> toEqual false);
+      test "negative range" (fun () -> expect (inRange ~lower:(-7.9) ~upper:(-5.2) (-6.6)) |> toEqual true);
+      test "nan upper bound" (fun () -> expect (inRange ~lower:(-7.9) ~upper:nan (-6.6)) |> toEqual false);
+      test "nan lower bound" (fun () -> expect (inRange ~lower:nan ~upper:0. (-6.6)) |> toEqual false);
+      test "nan value" (fun () -> expect (inRange ~lower:2. ~upper:8. nan) |> toEqual false);
+      test "invalid arguments" (fun () -> expect (fun () -> inRange ~lower:7. ~upper:1. 3.) |> toThrow);
+    );
+
+    test "hypotenuse" (fun () -> expect (hypotenuse 3. 4.) |> toEqual 5.);
+
+    test "degrees" (fun () -> expect (degrees 180.) |> toEqual pi);
+
+    test "radians" (fun () -> expect (radians pi) |> toEqual pi);
+
+    test "turns" (fun () -> expect (turns 1.) |> toEqual (2. * pi));
+
+    describe "fromPolar" (fun () ->
+      let (x, y) = fromPolar (squareRoot 2., degrees 45.) in
+      test "x" (fun () -> expect x |> toBeCloseTo 1.);
+      test "y" (fun () -> expect y |> toBeCloseTo 1.);
+    );
+
+    describe "toPolar" (fun () ->
+      test "toPolar" (fun () -> expect (toPolar (3.0, 4.0)) |> toEqual (5.0, 0.9272952180016122));
+
+      test "toPolar" (fun () -> expect (toPolar (5.0, 12.0)) |> toEqual (13.0, 1.1760052070951352));
+    );
+
+    describe "cos" (fun () ->
+      test "cos" (fun () -> expect (cos (degrees 60.)) |> toEqual 0.5000000000000001);
+
+      test "cos" (fun () -> expect (cos (radians (pi / 3.))) |> toEqual 0.5000000000000001);
+    );
+
+    describe "acos" (fun () ->
+      test "1 / 2" (fun () -> expect (acos (1. / 2.)) |> toEqual 1.0471975511965979 (* pi / 3. *));
+    );
+
+    describe "sin" (fun () ->
+      test "30 degrees" (fun () -> expect (sin (degrees 30.)) |> toEqual 0.49999999999999994);
+      test "pi / 6" (fun () -> expect (sin (radians (pi / 6.))) |> toEqual 0.49999999999999994);
+    );
+
+    describe "asin" (fun () ->
+      test "asin" (fun () -> expect (asin (1. / 2.)) |> toEqual 0.5235987755982989 (* ~ pi / 6. *));
+    );
+
+    describe "tan" (fun () ->
+      test "45 degrees" (fun () -> expect (tan (degrees 45.)) |> toEqual 0.9999999999999999);
+      test "pi / 4" (fun () -> expect (tan (radians (pi / 4.))) |> toEqual 0.9999999999999999);
+      test "0" (fun () -> expect (tan 0.) |> toEqual 0.);
+    );
+
+    describe "atan" (fun () ->
+      test "0" (fun () -> expect (atan 0.) |> toEqual 0. );
+      test "1 / 1" (fun () -> expect (atan (1. / 1.)) |> toEqual 0.7853981633974483);
+      test "1 / -1" (fun () -> expect (atan (1. / (-1.))) |> toEqual (-0.7853981633974483));
+      test "-1 / -1" (fun () -> expect (atan ((-1.) / (-1.))) |> toEqual 0.7853981633974483);
+      test "-1 / -1" (fun () -> expect (atan ((-1.) / 1.)) |> toEqual (-0.7853981633974483));
+    );
+
+    describe "atan2" (fun () ->
+      test "0" (fun () -> expect (atan2 ~y:0. ~x:0.) |> toEqual 0. );
+      test "(1, 1)" (fun () -> expect (atan2 ~y:1. ~x:1.) |> toEqual 0.7853981633974483);
+      test "(-1, 1)" (fun () -> expect (atan2 ~y:1. ~x:(-1.)) |> toEqual 2.3561944901923449);
+      test "(-1 -1)" (fun () -> expect (atan2 ~y:(-1.) ~x:(-1.)) |> toEqual (-2.3561944901923449));
+      test "(1, -1)" (fun () -> expect (atan2 ~y:(-1.) ~x:1.) |> toEqual (-0.7853981633974483));
+    );
+
+    describe "round" (fun () ->
+      test "`Zero" (fun () -> expect (round ~direction:`Zero 1.2) |> toEqual 1.);
+      test "`Zero" (fun () -> expect (round ~direction:`Zero 1.5) |> toEqual 1.);
+      test "`Zero" (fun () -> expect (round ~direction:`Zero 1.8) |> toEqual 1.);
+      test "`Zero" (fun () -> expect (round ~direction:(`Zero) (-1.2)) |> toEqual (-1.));
+      test "`Zero" (fun () -> expect (round ~direction:(`Zero) (-1.5)) |> toEqual (-1.));
+      test "`Zero" (fun () -> expect (round ~direction:(`Zero) (-1.8)) |> toEqual (-1.));
+
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) 1.2) |> toEqual 2.);
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) 1.5) |> toEqual 2.);
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) 1.8) |> toEqual 2.);
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) (-1.2)) |> toEqual (-2.));
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) (-1.5)) |> toEqual (-2.));
+      test "`AwayFromZero" (fun () -> expect (round ~direction:(`AwayFromZero) (-1.8)) |> toEqual (-2.));
+
+      test "`Up" (fun () -> expect (round ~direction:(`Up) 1.2) |> toEqual 2.);
+      test "`Up" (fun () -> expect (round ~direction:(`Up) 1.5) |> toEqual 2.);
+      test "`Up" (fun () -> expect (round ~direction:(`Up) 1.8) |> toEqual 2.);
+      test "`Up" (fun () -> expect (round ~direction:(`Up) (-1.2)) |> toEqual (-1.));
+      test "`Up" (fun () -> expect (round ~direction:(`Up) (-1.5)) |> toEqual (-1.));
+      test "`Up" (fun () -> expect (round ~direction:(`Up) (-1.8)) |> toEqual (-1.));
+
+      test "`Down" (fun () -> expect (round ~direction:(`Down) 1.2) |> toEqual 1.);
+      test "`Down" (fun () -> expect (round ~direction:(`Down) 1.5) |> toEqual 1.);
+      test "`Down" (fun () -> expect (round ~direction:(`Down) 1.8) |> toEqual 1.);
+      test "`Down" (fun () -> expect (round ~direction:(`Down) (-1.2)) |> toEqual (-2.));
+      test "`Down" (fun () -> expect (round ~direction:(`Down) (-1.5)) |> toEqual (-2.));
+      test "`Down" (fun () -> expect (round ~direction:(`Down) (-1.8)) |> toEqual (-2.));
+
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) 1.2) |> toEqual 1.);
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) 1.5) |> toEqual 1.);
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) 1.8) |> toEqual 2.);
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) (-1.2)) |> toEqual (-1.));
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) (-1.5)) |> toEqual (-1.));
+      test "`Closest `Zero" (fun () -> expect (round ~direction:(`Closest `Zero) (-1.8)) |> toEqual (-2.));
+
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) 1.2) |> toEqual 1.);
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) 1.5) |> toEqual 2.);
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) 1.8) |> toEqual 2.);
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) (-1.2)) |> toEqual (-1.));
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) (-1.5)) |> toEqual (-2.));
+      test "`Closest `AwayFromZero" (fun () -> expect (round ~direction:(`Closest `AwayFromZero) (-1.8)) |> toEqual (-2.));
+
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) 1.2) |> toEqual 1.);
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) 1.5) |> toEqual 2.);
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) 1.8) |> toEqual 2.);
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) (-1.2)) |> toEqual (-1.));
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) (-1.5)) |> toEqual (-1.));
+      test "`Closest `Up" (fun () -> expect (round ~direction:(`Closest `Up) (-1.8)) |> toEqual (-2.));
+
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) 1.2) |> toEqual 1.);
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) 1.5) |> toEqual 1.);
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) 1.8) |> toEqual 2.);
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) (-1.2)) |> toEqual (-1.));
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) (-1.5)) |> toEqual (-2.));
+      test "`Closest `Down" (fun () -> expect (round ~direction:(`Closest `Down) (-1.8)) |> toEqual (-2.));
+
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 1.2) |> toEqual 1.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 1.5) |> toEqual 2.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 1.8) |> toEqual 2.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 2.2) |> toEqual 2.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 2.5) |> toEqual 2.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) 2.8) |> toEqual 3.);
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-1.2)) |> toEqual (-1.));
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-1.5)) |> toEqual (-2.));
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-1.8)) |> toEqual (-2.));
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-2.2)) |> toEqual (-2.));
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-2.5)) |> toEqual (-2.));
+      test "`Closest `ToEven" (fun () -> expect (round ~direction:(`Closest `ToEven) (-2.8)) |> toEqual (-3.));
+    );
+
+    describe "floor" (fun () ->
+      test "floor" (fun () -> expect (floor 1.2) |> toEqual 1.);
+      test "floor" (fun () -> expect (floor 1.5) |> toEqual 1.);
+      test "floor" (fun () -> expect (floor 1.8) |> toEqual 1.);
+      test "floor" (fun () -> expect (floor (-1.2)) |> toEqual (-2.));
+      test "floor" (fun () -> expect (floor (-1.5)) |> toEqual (-2.));
+      test "floor" (fun () -> expect (floor (-1.8)) |> toEqual (-2.));
+    );
+
+    describe "ceiling" (fun () ->
+      test "ceiling" (fun () -> expect (ceiling 1.2) |> toEqual 2.);
+      test "ceiling" (fun () -> expect (ceiling 1.5) |> toEqual 2.);
+      test "ceiling" (fun () -> expect (ceiling 1.8) |> toEqual 2.);
+      test "ceiling" (fun () -> expect (ceiling (-1.2)) |> toEqual (-1.));
+      test "ceiling" (fun () -> expect (ceiling (-1.5)) |> toEqual (-1.));
+      test "ceiling" (fun () -> expect (ceiling (-1.8)) |> toEqual (-1.));
+    );
+
+    describe "truncate" (fun () ->
+      test "truncate" (fun () -> expect (truncate 1.2) |> toEqual 1.);
+      test "truncate" (fun () -> expect (truncate 1.5) |> toEqual 1.);
+      test "truncate" (fun () -> expect (truncate 1.8) |> toEqual 1.);
+      test "truncate" (fun () -> expect (truncate (-1.2)) |> toEqual (-1.));
+      test "truncate" (fun () -> expect (truncate (-1.5)) |> toEqual (-1.));
+      test "truncate" (fun () -> expect (truncate (-1.8)) |> toEqual (-1.));
+    );
+
+    describe "fromInt" (fun () ->
+      test "5" (fun () -> expect (fromInt 5) |> toEqual 5.0);
+      test "0" (fun () -> expect (fromInt 0) |> toEqual 0.0);
+      test "-7" (fun () -> expect (fromInt (-7)) |> toEqual (-7.0));
+    );
+
+    describe "toInt" (fun () ->
+      test "5." (fun () -> expect (toInt 5.) |> toEqual (Some 5));
+      test "5.3" (fun () -> expect (toInt 5.3) |> toEqual (Some 5));
+      test "0." (fun () -> expect (toInt 0.) |> toEqual (Some 0));
+      test "-7." (fun () -> expect (toInt (-7.)) |> toEqual (Some (-7)));
+      test "nan" (fun () -> expect (toInt nan) |> toEqual None);
+      test "infinity" (fun () -> expect (toInt infinity) |> toEqual None);
+      test "negativeInfinity" (fun () -> expect (toInt negativeInfinity) |> toEqual None);
+    );
+  ));
+
+  describe "Int" (fun () -> Int.(
+    test "zero" (fun () -> expect zero |> toEqual 0);
+
+    test "one" (fun () -> expect one |> toEqual 1);
+
+    test "minimumValue" (fun () -> expect (minimumValue - 1) |> toEqual maximumValue);
+
+    test "maximumValue" (fun () -> expect (maximumValue + 1) |> toEqual minimumValue);
+
+    describe "add" (fun () -> (
+      test "add" (fun () -> expect (add 3002 4004) |> toEqual 7006);
+      test "+" (fun () -> expect (3002 + 4004) |> toEqual 7006);
+    ));
+
+    describe "subtract" (fun () -> (
+      test "subtract" (fun () -> expect (subtract 4 3) |> toEqual 1);
+      test "-" (fun () -> expect (4 - 3) |> toEqual 1);
+    ));
+
+    describe "multiply" (fun () -> (
+      test "multiply" (fun () -> expect (multiply 2 7) |> toEqual 14);
+      test "*" (fun () -> expect (2 * 7) |> toEqual 14);
+    ));
+
+    describe "divide" (fun () -> (
+      test "divide" (fun () -> expect (divide 3 ~by:2) |> toEqual 1);
+      test "division by zero" (fun () -> expect (fun () -> divide 3 ~by:0) |> toThrow);
+
+      test "/" (fun () -> expect (27 / 5) |> toEqual 5);
+
+      test "//" (fun () -> expect (3 // 2) |> toEqual 1.5);
+      test "//" (fun () -> expect (27 // 5) |> toEqual 5.4);
+      test "//" (fun () -> expect (8 // 4) |> toEqual 2.0);
+
+      test "x // 0" (fun () -> expect (8 // 0) |> toEqual Float.infinity);
+      test "-x // 0" (fun () -> expect (-8 // 0) |> toEqual Float.negativeInfinity);
+    ));
+
+    describe "power" (fun () ->
+      test "power" (fun () -> expect (power ~base:7 ~exponent:3) |> toEqual 343);
+      test "0 base" (fun () -> expect (power ~base:0 ~exponent:3) |> toEqual 0);
+      test "0 exponent" (fun () -> expect (power ~base:7 ~exponent:0) |> toEqual 1);
+      test "**" (fun () -> expect (7 ** 3) |> toEqual 343);
+    );
+
+    describe "negate" (fun () ->
+      test "positive number" (fun () -> expect (negate 8) |> toEqual (-8));
+      test "negative number" (fun () -> expect (negate (-7)) |> toEqual 7);
+      test "zero" (fun () -> expect (negate 0) |> toEqual (-0));
+      test "~-" (fun () -> expect (~- 7) |> toEqual (-7));
+    );
+
+    describe "absolute" (fun () ->
+      test "positive number" (fun () -> expect (absolute 8) |> toEqual 8);
+      test "negative number" (fun () -> expect (absolute (-7)) |> toEqual 7);
+      test "zero" (fun () -> expect (absolute 0) |> toEqual 0);
+    );
+
+    describe "clamp" (fun () ->
+      test "in range" (fun () -> expect (clamp ~lower:0 ~upper:8 5) |> toEqual 5);
+      test "above range" (fun () -> expect (clamp ~lower:0 ~upper:8 9) |> toEqual 8);
+      test "below range" (fun () -> expect (clamp ~lower:2 ~upper:8 1) |> toEqual 2);
+      test "above negative range" (fun () -> expect (clamp ~lower:(-10) ~upper:(-5) 5) |> toEqual (-5));
+      test "below negative range" (fun () -> expect (clamp ~lower:(-10) ~upper:(-5) (-15)) |> toEqual (-10));
+      test "invalid arguments" (fun () -> expect (fun () -> clamp ~lower:7 ~upper:1 3) |> toThrow);
+    );
+
+    describe "inRange" (fun () ->
+      test "in range" (fun () -> expect (inRange ~lower:2 ~upper:4 3) |> toEqual true);
+      test "above range" (fun () -> expect (inRange ~lower:2 ~upper:4 8) |> toEqual false);
+      test "below range" (fun () -> expect (inRange ~lower:2 ~upper:4 1) |> toEqual false);
+      test "equal to ~upper" (fun () -> expect (inRange ~lower:1 ~upper:2 2) |> toEqual false);
+      test "negative range" (fun () -> expect (inRange ~lower:(-7) ~upper:(-5) (-6)) |> toEqual true);
+      test "invalid arguments" (fun () -> expect (fun () -> inRange ~lower:7 ~upper:1 3) |> toThrow);
+    );
+
+    describe "toFloat" (fun () ->
+      test "5" (fun () -> expect (toFloat 5) |> toEqual 5.);
+      test "0" (fun () -> expect (toFloat 0) |> toEqual 0.);
+      test "-7" (fun () -> expect (toFloat (-7)) |> toEqual (-7.));
+    );
+
+    describe "fromString" (fun () ->
+      test "0" (fun () -> expect (fromString "0") |> toEqual (Some 0));
+      test "-0" (fun () -> expect (fromString "-0") |> toEqual (Some (-0)));
+      test "42" (fun () -> expect (fromString "42") |> toEqual (Some 42));
+      test "123_456" (fun () -> expect (fromString "123_456") |> toEqual (Some 123_456));
+      test "-42" (fun () -> expect (fromString "-42") |> toEqual (Some (-42)));
+      test "0XFF" (fun () -> expect (fromString "0XFF") |> toEqual (Some 255));
+      test "0X000A" (fun () -> expect (fromString "0X000A") |> toEqual (Some 10));
+      test "Infinity" (fun () -> expect (fromString "Infinity") |> toEqual None);
+      test "-Infinity" (fun () -> expect (fromString "-Infinity") |> toEqual None);
+      test "NaN" (fun () -> expect (fromString "NaN") |> toEqual None);
+      test "abc" (fun () -> expect (fromString "abc") |> toEqual None);
+      test "--4" (fun () -> expect (fromString "--4") |> toEqual None);
+      test "empty string" (fun () -> expect (fromString " ") |> toEqual None);
+    );
+
+    describe "toString" (fun () ->
+      test "positive number" (fun () -> expect (toString 1) |> toEqual "1");
+      test "negative number" (fun () -> expect (toString (-1)) |> toEqual "-1");
+    );
+  ));
+
   describe "List" (fun () ->
     describe "reverse" (fun () ->
       test "reverse empty list" (fun () -> expect (List.reverse []) |> toEqual []);
@@ -419,27 +840,27 @@ let () =
       test "one element" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1]) |> toEqual ([], [1]));
       test "four elements" (fun () -> expect (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) |> toEqual ([2;4], [1;3]));
     );
- 
+
     describe "minimumBy" (fun () ->
       test "minimumBy non-empty list" (fun () -> expect (List.minimumBy ~f:(fun x -> x mod 12) [7;9;15;10;3;22]) |> toEqual (Some 15));
       test "minimumBy empty list" (fun () -> expect (List.minimumBy ~f:(fun x -> x mod 12) []) |> toEqual None);
     );
-    
+
     describe "maximumBy" (fun () ->
       test "maximumBy non-empty list" (fun () -> expect (List.maximumBy ~f:(fun x -> x mod 12) [7;9;15;10;3;22]) |> toEqual (Some 10));
       test "maximumBy empty list" (fun () -> expect (List.maximumBy ~f:(fun x -> x mod 12) []) |> toEqual None);
     );
-    
+
     describe "minimum" (fun () ->
       test "minimum non-empty list" (fun () -> expect (List.minimum [7; 9; 15; 10; 3]) |> toEqual (Some 3));
       test "minimum empty list" (fun () -> expect (List.minimum []) |> toEqual None);
     );
-    
+
     describe "maximum" (fun () ->
       test "maximum non-empty list" (fun () -> expect (List.maximum [7; 9; 15; 10; 3]) |> toEqual (Some 15));
       test "maximum empty list" (fun () -> expect (List.maximum []) |> toEqual None);
     );
-   
+
     describe "split_when" (fun () ->
       test "empty list" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) []) |> toEqual ([], []));
       test "at zero" (fun () -> expect (List.split_when ~f:(fun x -> x mod 2 = 0) [2;4;6]) |> toEqual ([], [2;4;6]));

--- a/bs/bsconfig.json
+++ b/bs/bsconfig.json
@@ -20,7 +20,8 @@
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"
   ],
-  "bsc-flags": ["-bs-g", "-bs-super-errors", "-warn-error", "@A", "-w", "-4-9-30-40-41-42-102"],
+  "bsc-flags": [
+    "-bs-g", "-bs-super-errors", "-warn-error", "@A", "-w", "-4-9-30-40-41-42-44-102"],
   "warnings": {
     "error" : "+101"
   },

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -2403,54 +2403,942 @@ module Char : sig
   val is_whitespace : char -> bool
 end
 
+module Float : sig
+  (** A module for working with {{: https://en.wikipedia.org/wiki/Floating-point_arithmetic } floating-point numbers}. Valid syntax for [float]s includes:
+    {[
+      0.
+      0.0
+      42.
+      42.0
+      3.14
+      0.1234
+      123_456.123_456
+      6.022e23   (* = (6.022 * 10^23) *)
+      6.022e+23  (* = (6.022 * 10^23) *)
+      1.602e−19  (* = (1.602 * 10^-19) *)
+      1e3        (* = (1 * 10 ** 3) = 1000. *)
+    ]}
+
+    Without opening this module you can use the [.] suffixed operators e.g
+
+    {[ 1. +. 2. /. 0.25 *. 2. = 17. ]}
+
+    But by opening this module locally you can use the un-suffixed operators
+
+    {[Float.((10.0 - 1.5 / 0.5) ** 3.0) = 2401.0]}
+
+    {b Historical Note: } The particular details of floats (e.g. [NaN]) are
+    specified by {{: https://en.wikipedia.org/wiki/IEEE_754 } IEEE 754 } which is literally hard-coded into almost all
+    CPUs in the world.
+  *)
+
+  type t = float
+
+  (** {1 Constants} *)
+
+  val zero : t
+  (** The literal [0.0] as a named value *)
+
+  val one : t
+  (** The literal [1.0] as a named value *)
+
+  val nan : t
+  (** [NaN] as a named value. NaN stands for {{: https://en.wikipedia.org/wiki/NaN } not a number}.
+
+      {b Note } comparing values with {!Float.nan} will {b always return } [false] even if the value you are comparing against is also [NaN].
+
+      e.g
+
+      {[
+let isNotANmber x = Float.(x = nan) in
+isNotANumber nan = false
+
+
+]}
+
+      For detecting [Nan] you should use {!Float.isNaN}
+
+  *)
+
+  val infinity : t
+  (** Positive {{: https://en.wikipedia.org/wiki/IEEE_754-1985#Positive_and_negative_infinity } infinity }
+
+    {[Float.log ~base:10.0 0.0 = Float.infinity]} *)
+
+  val negativeInfinity : t
+  (** Negative infinity, see {!Float.infinity} *)
+
+  val negative_infinity : t
+
+  val e : t
+  (** An approximation of {{: https://en.wikipedia.org/wiki/E_(mathematical_constant) } Euler's number }. *)
+
+  val pi : t
+  (** An approximation of {{: https://en.wikipedia.org/wiki/Pi } pi }. *)
+
+  (** {1 Basic arithmetic and operators} *)
+
+  val add : t -> t -> t
+  (** Addition for floating point numbers.
+
+    {[Float.add 3.14 3.14 = 6.28]}
+
+    {[Float.(3.14 + 3.14 = 6.28)]}
+
+    Although [int]s and [float]s support many of the same basic operations such as
+    addition and subtraction you {b cannot} [add] an [int] and a [float] directly which
+    means you need to use functions like {!Int.toFloat} or {!Float.roundToInt} to convert both values to the same type.
+
+    So if you needed to add a {!List.length} to a [float] for some reason, you
+    could:
+
+    {[Float.add 3.14 (Int.toFloat (List.length [1,2,3])) = 6.14]}
+
+    or
+
+    {[Float.roundToInt 3.14 + List.length [1,2,3] = 6]}
+
+    Languages like Java and JavaScript automatically convert [int] values
+    to [float] values when you mix and match. This can make it difficult to be sure
+    exactly what type of number you are dealing with and cause unexpected behavior.
+
+    OCaml has opted for a design that makes all conversions explicit.
+  *)
+
+  val ( + ) : t -> t -> t
+  (** See {!Float.add} *)
+
+  val subtract : t -> t -> t
+  (** Subtract numbers
+    {[Float.subtract 4.0 3.0 = 1.0]}
+
+    Alternatively the [-] operator can be used:
+
+    {[Float.(4.0 - 3.0) = 1.0]}
+  *)
+
+  val ( - ) : t -> t -> t
+  (** See {!Float.subtract} *)
+
+  val multiply : t -> t -> t
+  (** Multiply numbers like
+
+    {[Float.multiply 2.0 7.0 = 14.0]}
+
+    Alternatively the [*] operator can be used:
+
+    {[Float.(2.0 * 7.0) = 14.0]}
+  *)
+
+  val ( * ) : t -> t -> t
+  (** See {!Float.multiply} *)
+
+  val divide : t -> by:t -> t
+  (** Floating-point division:
+
+    {[Float.divide 3.14 ~by:2.0 = 1.57]}
+
+    Alternatively the [/] operator can be used:
+
+    {[Float.(3.14 / 2.0) = 1.57]} *)
+
+  val ( / ) : t -> t -> t
+  (** See {!Float.divide} *)
+
+  val power : base:t -> exponent:t -> t
+  (** Exponentiation, takes the base first, then the exponent.
+
+    {[Float.power ~base:7.0 ~exponent:3.0 = 343.0]}
+
+    Alternatively the [**] operator can be used:
+
+    {[Float.(7.0 ** 3.0) = 343.0]}
+  *)
+
+  val ( ** ) : t -> t -> t
+  (** See {!Float.power} *)
+
+  val negate : t -> t
+  (** Flips the 'sign' of a [float] so that positive floats become negative and negative integers become positive. Zero stays as it is.
+
+    {[Float.negate 8 = (-8)]}
+
+    {[Float.negate (-7) = 7]}
+
+    {[Float.negate 0 = 0]}
+
+    Alternatively an operator is available:
+
+    {[Float.(~- 4.0) = (-4.0)]}
+  *)
+
+  val (~-) : t -> t
+  (** See {!Float.negate} *)
+
+  val absolute : t -> t
+  (** Get the {{: https://en.wikipedia.org/wiki/Absolute_value } absolute value} of a number.
+
+    {[Float.absolute 8. = 8.]}
+
+    {[Float.absolute (-7) = 7]}
+
+    {[Float.absolute 0 = 0]}
+  *)
+
+  val maximum : t -> t -> t
+   (** Returns the larger of two [float]s, if both arguments are equal, returns the first argument
+
+    {[Float.maximum 7. 9. = 9.]}
+
+    {[Float.maximum (-4.) (-1.) = (-1.)]}
+
+    If either (or both) of the arguments are [NaN], returns [NaN]
+
+    {[Float.(isNaN (maximum 7. nan) = true]}
+  *)
+
+  val minimum : t -> t -> t
+  (** Returns the smaller of two [float]s, if both arguments are equal, returns the first argument
+
+    {[Float.minimum 7.0 9.0 = 7.0]}
+
+    {[Float.minimum (-4.0) (-1.0) = (-4.0)]}
+
+    If either (or both) of the arguments are [NaN], returns [NaN]
+
+    {[Float.(isNaN (minimum 7. nan) = true]}
+  *)
+
+  val clamp : t -> lower:t -> upper:t -> t
+  (** Clamps [n] within the inclusive [lower] and [upper] bounds.
+
+    {[Float.clamp ~lower:0. ~upper:8. 5. = 5.]}
+
+    {[Float.clamp ~lower:0. ~upper:8. 9. = 8.]}
+
+    {[Float.clamp ~lower:(-10.) ~upper:(-5.) 5. = -5.]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  (** {1 Fancier math} *)
+
+  val squareRoot : t -> t
+  (** Take the square root of a number.
+    {[Float.squareRoot 4.0 = 2.0]}
+
+    {[Float.squareRoot 9.0 = 3.0]}
+
+    [squareRoot] returns [NaN] when its argument is negative. See {!Float.nan} for more.
+  *)
+
+  val square_root : t -> t
+
+  val log : t -> base:t -> t
+  (** Calculate the logarithm of a number with a given base.
+
+    {[Float.log ~base:10. 100. = 2.]}
+
+    {[Float.log ~base:2. 256. = 8.]}
+  *)
+
+  (** {1 Checks} *)
+
+  val isNaN : t -> bool
+  (** Determine whether a float is an undefined or unrepresentable number.
+
+    {[Float.isNaN (0.0 / 0.0) = true]}
+
+    {[Float.(isNaN (squareRoot (-1.0)) = true]}
+
+    {[Float.isNaN (1.0 / 0.0) = false  (* Float.infinity {b is} a number *)]}
+
+    {[Float.isNaN 1. = false]}
+
+    {b Note } this function is more useful than it might seem since [NaN] {b does not } equal [Nan]:
+
+    {[Float.(nan = nan) = false]}
+  *)
+
+  val is_nan : t -> bool
+
+  val isFinite : t -> bool
+  (** Determine whether a float is finite number. True for any float except [Infinity], [-Infinity] or [NaN]
+
+    {[Float.isFinite (0. / 0.) = false]}
+
+    {[Float.(isFinite (squareRoot (-1.)) = false]}
+
+    {[Float.isFinite (1. / 0.) = false]}
+
+    {[Float.isFinite 1. = true]}
+
+    {[Float.(isFinite nan) = false]}
+
+    Notice that [NaN] is not finite!
+
+    For a [float] [n] to be finite implies that [Float.(not (isInfinite n || isNaN n))] evaluates to [true].
+  *)
+
+  val is_finite : t -> bool
+
+  val isInfinite : t -> bool
+  (** Determine whether a float is positive or negative infinity.
+
+    {[Float.isInfinite (0. / 0.) = false]}
+
+    {[Float.(isInfinite (squareRoot (-1.)) = false]}
+
+    {[Float.isInfinite (1. / 0.) = true]}
+
+    {[Float.isInfinite 1. = false]}
+
+    {[Float.(isInfinite nan) = false]}
+
+    Notice that [NaN] is not infinite!
+
+    For a [float] [n] to be finite implies that [Float.(not (isInfinite n || isNaN n))] evaluates to [true].
+  *)
+
+  val is_infinite : t -> bool
+
+  val inRange : t -> lower:t -> upper:t -> bool
+  (** Checks if [n] is between [lower] and up to, but not including, [upper].
+    If [lower] is not specified, it's set to to [0.0].
+
+    {[Float.inRange ~lower:2. ~upper:4. 3. = true]}
+
+    {[Float.inRange ~lower:1. ~upper:2. 2. = false]}
+
+    {[Float.inRange ~lower:5.2 ~upper:7.9 9.6 = false]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val in_range : t -> lower:t -> upper:t -> bool
+
+  (** {1 Angles} *)
+
+  val hypotenuse : t -> t -> t
+  (** [hypotenuse x y] returns the length of the hypotenuse of a right-angled triangle with sides of length [x] and [y], or, equivalently, the distance of the point [(x, y)] to [(0, 0)].
+
+    {[Float.hypotenuse 3. 4. = 5.]}
+  *)
+
+  val degrees : t -> t
+  (** Converts an angle in {{: https://en.wikipedia.org/wiki/Degree_(angle) } degrees} to {!Float.radians}.
+
+    {[Float.degrees 180. = v]}
+  *)
+
+  val radians : t -> t
+  (** Convert a {!Float.t} to {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(radians pi) = 3.141592653589793]}
+
+    {b Note } This function doesn't actually do anything to its argument, but can be useful to indicate intent when inter-mixing angles of different units within the same function.
+  *)
+
+  val turns : t -> t
+  (** Convert an angle in {{: https://en.wikipedia.org/wiki/Turn_(geometry) } turns } into {!Float.radians}.
+
+    One turn is equal to 360°.
+
+    {[Float.(turns (1. / 2.)) = pi]}
+
+    {[Float.(turns 1. = degrees 360.)]}
+  *)
+
+  (** {1 Polar coordinates} *)
+
+  val fromPolar : (float * float) -> (float * float)
+  (** Convert {{: https://en.wikipedia.org/wiki/Polar_coordinate_system } polar coordinates } (r, θ) to {{: https://en.wikipedia.org/wiki/Cartesian_coordinate_system } Cartesian coordinates } (x,y).
+
+    {[Float.(fromPolar (squareRoot 2., degrees 45.)) = (1., 1.)]}
+  *)
+
+  val from_polar : (float * float) -> (float * float)
+
+  val toPolar : (float * float) -> (float * float)
+  (** Convert {{: https://en.wikipedia.org/wiki/Cartesian_coordinate_system } Cartesian coordinates } (x,y) to {{: https://en.wikipedia.org/wiki/Polar_coordinate_system } polar coordinates } (r, θ).
+
+    {[Float.toPolar (3.0, 4.0) = (5.0, 0.9272952180016122)]}
+
+    {[Float.toPolar (5.0, 12.0) = (13.0, 1.1760052070951352)]}
+  *)
+
+  val to_polar : (float * float) -> (float * float)
+
+  val cos : t -> t
+  (** Figure out the cosine given an angle in {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(cos (degrees 60.)) = 0.5000000000000001]}
+
+    {[Float.(cos (radians (pi / 3.))) = 0.5000000000000001]}
+  *)
+
+  val acos : t -> t
+  (** Figure out the arccosine for [adjacent / hypotenuse] in {{: https://en.wikipedia.org/wiki/Radian } radians }:
+
+    {[Float.(acos (radians 1.0 / 2.0)) = Float.radians 1.0471975511965979 (* 60° or pi/3 radians *)]}
+  *)
+
+  val sin : t -> t
+  (** Figure out the sine given an angle in {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(sin (degrees 30.)) = 0.49999999999999994]}
+
+    {[Float.(sin (radians (pi / 6.)) = 0.49999999999999994]}
+  *)
+
+  val asin : t -> t
+  (** Figure out the arcsine for [opposite / hypotenuse] in {{: https://en.wikipedia.org/wiki/Radian } radians }:
+
+    {[Float.(asin (1.0 / 2.0)) = 0.5235987755982989 (* 30° or pi / 6 radians *)]}
+  *)
+
+  val tan : t -> t
+  (** Figure out the tangent given an angle in radians.
+
+    {[Float.(tan (degrees 45.)) = 0.9999999999999999]}
+
+    {[Float.(tan (radians (pi / 4.)) = 0.9999999999999999]}
+
+    {[Float.(tan (pi / 4.)) = 0.9999999999999999]}
+  *)
+
+  val atan : t -> t
+  (** This helps you find the angle (in radians) to an [(x, y)] coordinate, but
+    in a way that is rarely useful in programming.
+
+    {b You probably want } {!atan2} instead!
+
+    This version takes [y / x] as its argument, so there is no way to know whether
+    the negative signs comes from the [y] or [x] value. So as we go counter-clockwise
+    around the origin from point [(1, 1)] to [(1, -1)] to [(-1,-1)] to [(-1,1)] we do
+    not get angles that go in the full circle:
+
+    {[Float.atan (1. /. 1.) = 0.7853981633974483  (* 45° or pi/4 radians *)]}
+
+    {[Float.atan (1. /. -1.) = -0.7853981633974483  (* 315° or 7 * pi / 4 radians *)]}
+
+    {[Float.atan (-1. /. -1.) = 0.7853981633974483 (* 45° or pi/4 radians *)]}
+
+    {[Float.atan (-1. /.  1.) = -0.7853981633974483 (* 315° or 7 * pi/4 radians *)]}
+
+    Notice that everything is between [pi / 2] and [-pi/2]. That is pretty useless
+    for figuring out angles in any sort of visualization, so again, check out
+    {!Float.atan2} instead!
+  *)
+
+  val atan2 : y:t -> x:t -> t
+  (** This helps you find the angle (in radians) to an [(x, y)] coordinate. So rather than saying [Float.(atan (y / x))] you can [Float.atan2 ~y ~x] and you can get a full range of angles:
+
+    {[Float.atan2 ~y:1. ~x:1. = 0.7853981633974483  (* 45° or pi/4 radians *)]}
+
+    {[Float.atan2 ~y:1. ~x:(-1.) = 2.3561944901923449  (* 135° or 3 * pi/4 radians *)]}
+
+    {[Float.atan2 ~y:(-1.) ~x:(-1.) = -(2.3561944901923449) (* 225° or 5 * pi/4 radians *)]}
+
+    {[Float.atan2 ~y:(-1.) ~x:1.) = -(0.7853981633974483) (* 315° or 7 * pi/4 radians *)]}
+  *)
+
+  (** {1 Conversion} *)
+
+  type direction = [
+    | `Zero
+    | `AwayFromZero
+    | `Up
+    | `Down
+    | `Closest of [
+      | `Zero
+      | `AwayFromZero
+      | `Up
+      | `Down
+      | `ToEven
+    ]
+  ]
+
+  val round : ?direction:direction -> t ->  t
+  (** Round a number, by default to the to the closest [int] with halves rounded [`Up] (towards positive infinity)
+
+    {[
+Float.round 1.2 = 1.0
+Float.round 1.5 = 2.0
+Float.round 1.8 = 2.0
+Float.round -1.2 = -1.0
+Float.round -1.5 = -1.0
+Float.round -1.8 = -2.0
+    ]}
+
+    Other rounding strategies are available by using the optional [~direction] label.
+
+    {2 Towards zero}
+
+    {[
+Float.round ~direction:`Zero 1.2 = 1.0
+Float.round ~direction:`Zero 1.5 = 1.0
+Float.round ~direction:`Zero 1.8 = 1.0
+Float.round ~direction:`Zero (-1.2) = -1.0
+Float.round ~direction:`Zero (-1.5) = -1.0
+Float.round ~direction:`Zero (-1.8) = -1.0
+    ]}
+
+    {2 Away from zero}
+
+    {[
+Float.round ~direction:`AwayFromZero 1.2 = 1.0
+Float.round ~direction:`AwayFromZero 1.5 = 1.0
+Float.round ~direction:`AwayFromZero 1.8 = 1.0
+Float.round ~direction:`AwayFromZero (-1.2) = -1.0
+Float.round ~direction:`AwayFromZero (-1.5) = -1.0
+Float.round ~direction:`AwayFromZero (-1.8) = -1.0
+    ]}
+
+    {2 Towards infinity}
+
+    This is also known as {!Float.ceiling}
+
+    {[
+Float.round ~direction:`Up 1.2 = 1.0
+Float.round ~direction:`Up 1.5 = 1.0
+Float.round ~direction:`Up 1.8 = 1.0
+Float.round ~direction:`Up (-1.2) = -1.0
+Float.round ~direction:`Up (-1.5) = -1.0
+Float.round ~direction:`Up (-1.8) = -1.0
+    ]}
+
+    {2 Towards negative infinity}
+
+    This is also known as {!Float.floor}
+
+    {[List.map  ~f:(Float.round ~direction:`Down) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -2.0; 1.0 1.0 1.0]]}
+
+    {2 To the closest integer}
+
+    Rounding a number [x] to the closest integer requires some tie-breaking for when the [fraction] part of [x] is exactly [0.5].
+
+    {3 Halves rounded towards zero}
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `AwayFromZero)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -1.0; -1.0; 1.0 1.0 2.0]]}
+
+    {3 Halves rounded away from zero}
+
+    This method is often known as {b commercial rounding }
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `AwayFromZero)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -1.0; 1.0 2.0 2.0]]}
+
+    {3 Halves rounded down}
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `Down)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -1.0; 1.0 1.0 2.0]]}
+
+    {3 Halves rounded up}
+
+    This is the default.
+
+    [Float.round 1.5] is the same as [Float.round ~direction:(`Closest `Up) 1.5]
+
+    {3 Halves rounded towards the closest even number}
+
+    This tie-breaking rule is the default rounding mode using in
+
+    {[Float.round ~direction:(`Closest `ToEven) -1.5 = -2.0]}
+
+    {[Float.round ~direction:(`Closest `ToEven) -2.5 = -2.0]}
+  *)
+
+  val floor : t -> t
+  (** Floor function, equivalent to [Float.round ~direction:`Down].
+
+    {[Float.floor 1.2 = 1.0]}
+
+    {[Float.floor 1.5 = 1.0]}
+
+    {[Float.floor 1.8 = 1.0]}
+
+    {[Float.floor -1.2 = -2.0]}
+
+    {[Float.floor -1.5 = -2.0]}
+
+    {[Float.floor -1.8 = -2.0]}
+  *)
+
+  val ceiling : t -> t
+  (** Ceiling function, equivalent to [Float.round ~direction:`Up].
+
+    {[Float.ceiling 1.2 = 2.0]}
+
+    {[Float.ceiling 1.5 = 2.0]}
+
+    {[Float.ceiling 1.8 = 2.0]}
+
+    {[Float.ceiling -1.2 = (-1.0)]}
+
+    {[Float.ceiling -1.5 = (-1.0)]}
+
+    {[Float.ceiling -1.8 = (-1.0)]}
+  *)
+
+  val truncate : t -> t
+  (** Ceiling function, equivalent to [Float.round ~direction:`Zero].
+
+    {[Float.truncate 1.0 = 1]}
+
+    {[Float.truncate 1.2 = 1]}
+
+    {[Float.truncate 1.5 = 1]}
+
+    {[Float.truncate 1.8 = 1]}
+
+    {[Float.truncate (-1.2) = -1]}
+
+    {[Float.truncate (-1.5) = -1]}
+
+    {[Float.truncate (-1.8) = -1]}
+  *)
+
+  val fromInt : int -> float
+  (** Convert an [int] to a [float]
+
+    {[Float.fromInt 5 = 5.0]}
+
+    {[Float.fromInt 0 = 0.0]}
+
+    {[Float.fromInt -7 = -7.0]}
+  *)
+
+  val from_int : int -> float
+
+  val toInt : t ->  int option
+  (** Converts a [float] to an {!Int} by {b ignoring the decimal portion}. See {!Float.truncate} for examples.
+
+    Returns [None] when trying to round a [float] which can't be represented as an [int] such as {!Float.nan} or {!Float.infinity} or numbers which are too large or small.
+
+    {[Float.(toInt nan) = None]}
+
+    {[Float.(toInt infinity) = None]}
+
+    You probably want to use some form of {!Float.round} prior to using this function.
+
+    {[Float.(round 1.6 |> toInt) = Some 2]}
+  *)
+
+  val to_int : t ->  int option
+end
+
 module Int : sig
+  (** The platform-dependant {{: https://en.wikipedia.org/wiki/Integer } signed } {{: https://en.wikipedia.org/wiki/Integer } integer} type. An [int] is a whole number.
+    Valid syntax for [int]s includes:
+    {[
+      0
+      42
+      9000
+      1_000_000
+      1_000_000
+      0xFF (* 255 in hexadecimal *)
+      0x000A (* 10 in hexadecimal *)
+    ]}
 
-  (**
-    `negate n` (`negate(n) in ReasonML) returns the negative
-    value of the given integer.
-    
-    ### Example
-    ```ocaml
-    negate (-3) = 3
-    negate 5 = (-5)
-    negate 0 = 0
-    ```
-    
-    ```reason
-    negate(-3) == 3;
-    negate(5) == -5;
-    negate(0) == 0;
-    ```
-  *)
-  val negate : int -> int
+    {b Note:} The number of bits used for an [int] is platform dependent.
 
-  (**
-    `isEven(n)` returns `true` if `n` is even, `false` otherwise.
-    
-    (Same as `is_even`.)
-  *)
-  val isEven : int -> bool
+    When targeting native OCaml uses 31-bits on a 32-bit platforms and 63-bits on a 64-bit platforms
+    which means that [int] math is well-defined in the range [-2 ** 30] to [2 ** 30 - 1] for 32bit platforms [-2 ** 62] to [2 ** 62 - 1] for 64bit platforms.
 
-  (**
-    `is_even n` returns `true` if `n` is even, `false` otherwise.
-  
-    (Same as `isEven`.)
-  *)
-  val is_even : int -> bool
+    You can read about the reasons for OCamls unusual integer sizes {{: https://v1.realworldocaml.org/v1/en/html/memory-representation-of-values.html} here }.
 
-  (**
-    `isOdd(n)` returns `true` if `n` is odd, `false` otherwise.
-    
-    (Same as `is_odd.`)
-  *)
-  val isOdd : int -> bool
+    When targeting JavaScript, that range is [-2 ** 53] to [2 ** 53 - 1].
 
-  (**
-    `is_odd n` returns `true` if `n` is even, `false` otherwise.
-    
-    (Same as `isOdd`.)
+    Outside of that range, the behavior is determined by the compilation target.
+
+    [int]s are subject to {{: https://en.wikipedia.org/wiki/Integer_overflow } overflow }, meaning that [Int.maximumValue + 1 = Int.minimumValue].
+
+    {e Historical Note: } The name [int] comes from the term {{: https://en.wikipedia.org/wiki/Integer } integer}). It appears
+    that the [int] abbreviation was introduced in the programming language ALGOL 68.
+
+    Today, almost all programming languages use this abbreviation.
   *)
-  val is_odd : int -> bool
+
+  type t = int
+
+  (** {1 Constants } *)
+
+  val zero : t
+  (** The literal [0] as a named value *)
+
+  val one : t
+  (** The literal [1] as a named value *)
+
+  val maximumValue : t
+  (** The maximum representable [int] on the current platform *)
+
+  val maximum_value : t
+
+  val minimumValue : t
+  (** The minimum representable [int] on the current platform *)
+
+  val minimum_value : t
+
+  (** {1 Operators }
+    {b Note } You do not need to open the {!Int} module to use the {!( + )}, {!( - )}, {!( * )} or {!( / )} operators, these are available as soon as you [open Tablecloth]
+  *)
+
+  val add : t -> t -> t
+  (** Add two {!Int} numbers.
+
+    {[Int.add 3002 4004 = 7006]}
+
+    Or using the globally available operator:
+
+    {[3002 + 4004 = 7006]}
+
+    You {e cannot } add an [int] and a [float] directly though.
+
+    See {!Float.add} for why, and how to overcome this limitation.
+  *)
+
+  val ( + ) : t -> t -> t
+  (** See {!Int.add} *)
+
+  val subtract : t -> t -> t
+  (** Subtract numbers
+    {[Int.subtract 4 3 = 1]}
+
+    Alternatively the operator can be used:
+
+    {[4 - 3 = 1]}
+  *)
+
+  val ( - ) : t -> t -> t
+  (** See {!Int.subtract} *)
+
+  val multiply : t -> t -> t
+  (** Multiply [int]s like
+
+    {[Int.multiply 2 7 = 14]}
+
+    Alternatively the operator can be used:
+
+    {[(2 * 7) = 14]}
+  *)
+
+  val ( * ) : t -> t -> t
+  (** See {!Int.multiply} *)
+
+  val divide : t -> by:t -> t
+  (** Integer division:
+
+    {[Int.divide 3 ~by:2 = 1]}
+
+    {[27 / 5 = 5]}
+
+    Notice that the remainder is discarded.
+
+    Throws [Division_by_zero] when the divisor is [0].
+  *)
+
+  val ( / ) : t -> t -> t
+  (** See {!Int.divide} *)
+
+  val ( // ) : t -> t -> float
+  (** Floating point division
+    {[3 // 2 = 1.5]}
+
+    {[27 // 5 = 5.25]}
+
+    {[8 // 4 = 2.0]}
+  *)
+
+  val power : base:t -> exponent:t -> t
+  (** Exponentiation, takes the base first, then the exponent.
+
+    {[Int.power ~base:7 ~exponent:3 = 343]}  
+
+    Alternatively the [**] operator can be used:
+
+    {[7 ** 3 = 343]}
+  *)
+
+  val ( ** ) : t -> t -> t
+  (** See {!Int.power} *)
+
+  val negate : t -> t
+  (** Flips the 'sign' of an integer so that positive integers become negative and negative integers become positive. Zero stays as it is.
+
+    {[Int.negate 8 = (-8)]}
+
+    {[Int.negate (-7) = 7]}
+
+    {[Int.negate 0 = 0]}
+
+    Alternatively the operator can be used:
+
+    {[~-(7) = (-7)]}
+  *)
+
+  val (~-) : t -> t
+  (** See {!Int.negate} *)
+
+  val absolute : t -> t
+  (** Get the {{: https://en.wikipedia.org/wiki/Absolute_value } absolute value } of a number.
+
+    {[Int.absolute 8 = 8]}
+
+    {[Int.absolute (-7) = 7]}
+
+    {[Int.absolute 0 = 0]} *)
+
+  val modulo : t -> by:t -> t
+  (** Perform {{: https://en.wikipedia.org/wiki/Modular_arithmetic } modular arithmetic }.
+
+    If you intend to use [modulo] to detect even and odd numbers consider using {!Int.isEven} or {!Int.isOdd}.
+
+    {[Int.modulo ~by:2 0 = 0]}
+
+    {[Int.modulo ~by:2 1 = 1]}
+
+    {[Int.modulo ~by:2 2 = 0]}
+
+    {[Int.modulo ~by:2 3 = 1]}
+
+    Our [modulo] function works in the typical mathematical way when you run into negative numbers:
+
+    {[
+      List.map ~f:(Int.modulo ~by:4) [(-5); (-4); -3; -2; -1;  0;  1;  2;  3;  4;  5 ] =
+        [3; 0; 1; 2; 3; 0; 1; 2; 3; 0; 1]
+    ]}
+
+    Use {!Int.remainder} for a different treatment of negative numbers.
+  *)
+
+  val remainder : t -> by:t -> t
+  (** Get the remainder after division. Here are bunch of examples of dividing by four:
+
+    {[
+      List.map ~f:(Int.remainder ~by:4) [(-5); (-4); (-3); (-2); (-1); 0; 1; 2; 3; 4; 5] =
+        [(-1); 0; (-3); (-2); (-1); 0; 1; 2; 3; 0; 1]
+    ]}
+
+
+    Use {!Int.modulo} for a different treatment of negative numbers.
+  *)
+
+  val maximum : t -> t -> t
+  (** Returns the larger of two [int]s
+
+    {[Int.maximum 7 9 = 9]}
+
+    {[Int.maximum (-4) (-1) = (-1)]} *)
+
+  val minimum : t -> t -> t
+  (** Returns the smaller of two [int]s
+
+    {[Int.minimum 7 9 = 7]}
+
+    {[Int.minimum (-4) (-1) = (-4)]} *)
+
+  (** {1 Checks} *)
+
+  val isEven : t -> bool
+  (** Check if an [int] is even
+
+    {[Int.isEven 8 = true]}
+
+    {[Int.isEven 7 = false]}
+
+    {[Int.isEven 0 = true]} *)
+
+  val is_even : t -> bool
+
+  val isOdd : t -> bool
+  (** Check if an [int] is odd
+
+    {[Int.isOdd 7 = true]}
+
+    {[Int.isOdd 8 = false]}
+
+    {[Int.isOdd 0 = false]} *)
+
+  val is_odd : t -> bool
+
+  val clamp : t -> lower:t -> upper:t -> t
+  (** Clamps [n] within the inclusive [lower] and [upper] bounds.
+
+    {[Int.clamp ~lower:0 ~upper:8 5 = 5]}
+
+    {[Int.clamp ~lower:0 ~upper:8 9 = 8]}
+
+    {[Int.clamp ~lower:(-10) ~upper:(-5) 5 = (-5)]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val inRange : t -> lower:t -> upper:t -> bool
+  (** Checks if [n] is between [lower] and up to, but not including, [upper].
+
+    {[Int.inRange ~lower:2 ~upper:4 3 = true]}
+
+    {[Int.inRange ~lower:5 ~upper:8 4 = false]}
+
+    {[Int.inRange ~lower:(-6) ~upper:(-2) (-3) = true]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val in_range : t -> lower:t -> upper:t -> bool
+
+  (** {1 Conversion } *)
+
+  val toFloat : t -> float
+  (** Convert an integer into a float. Useful when mixing {!Int} and {!Float} values like this:
+
+    {[
+let halfOf (number : int) : float =
+  Float.((Int.toFloat number) / 2)
+
+halfOf 7 = 3.5
+    ]}
+    Note that locally opening the {!Float} module here allows us to use the floating point division operator
+  *)
+
+  val to_float : t -> float
+
+  val toString : t -> string
+  (** Convert an [int] into a [string] representation.
+
+    {[Int.toString 3 = "3"]}
+
+    {[Int.toString (-3) = "-3"]}
+
+    {[Int.toString 0 = "0"]}
+
+    Guarantees that
+
+    {[Int.(fromString (toString n)) = Some n ]}
+ *)
+
+  val to_string : t -> string
+
+  val fromString : string -> t option
+  (** Attempt to parse a [string] into a [int].
+
+    {[Int.fromString "0" = Some 0.]}
+
+    {[Int.fromString "42" = Some 42.]}
+
+    {[Int.fromString "-3" = Some (-3)]}
+
+    {[Int.fromString "123_456" = Some 123_456]}
+
+    {[Int.fromString "0xFF" = Some 255]}
+
+    {[Int.fromString "0x00A" = Some 10]}
+
+    {[Int.fromString "Infinity" = None]}
+
+    {[Int.fromString "NaN" = None]}
+  *)
+
+  val from_string : string -> t option
 end
 
 module Tuple2 : sig

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -688,20 +688,277 @@ module Char = struct
   let is_printable = isPrintable
 
   let isWhitespace = Base.Char.is_whitespace
-  
+
   let is_whitespace = isWhitespace
 end
 
+module Float = struct
+  type t = float
+
+  let add = (+.)
+
+  let (+) = (+.)
+
+  let subtract = (-.)
+
+  let (-) = (-.)
+
+  let multiply = ( *. )
+
+  let ( * ) = ( *. )
+
+  let divide n ~by = (n /. by)
+
+  let ( / ) = ( /. )
+
+  let power ~base ~exponent = (base ** exponent) 
+
+  let ( ** ) = ( ** )
+
+  let negate = Base.Float.neg
+
+  let (~-) = negate
+
+  let absolute = Base.Float.abs
+
+  let clamp n ~lower ~upper =
+    if upper < lower then
+      raise (
+        Invalid_argument ("~lower:" ^ (Base.Float.to_string lower) ^ " must be less than or equal to ~upper:" ^ (Base.Float.to_string upper))
+      )
+    else if (Base.Float.is_nan lower || Base.Float.is_nan upper || Base.Float.is_nan n) then
+      Base.Float.nan
+    else
+      max lower (min upper n)
+
+  let inRange n ~lower ~upper =
+    if Base.Float.(upper < lower) then
+      raise (
+        Invalid_argument ("~lower:" ^ (Base.Float.to_string lower) ^ " must be less than or equal to ~upper:" ^ (Base.Float.to_string upper))
+      )
+    else
+      n >= lower && n < upper
+
+  let in_range = inRange
+
+  let squareRoot = sqrt
+
+  let square_root = squareRoot
+
+  let log n ~base = Base.Float.(log10(n) / log10(base))
+
+  let zero = 0.0
+
+  let one = 1.0
+
+  let nan = Base.Float.nan
+
+  let infinity = Base.Float.infinity
+
+  let negativeInfinity = Base.Float.neg_infinity
+
+  let negative_infinity = negativeInfinity
+
+  let e = Base.Float.euler
+
+  let pi = Base.Float.pi
+
+  let isNaN = Base.Float.is_nan
+
+  let is_nan = isNaN
+
+  let isInfinite = Base.Float.is_inf
+
+  let is_infinite = isInfinite
+
+  let isFinite n = not (isInfinite n) && not (isNaN n)
+
+  let is_finite = isFinite
+
+  let maximum x y =
+    if isNaN x || isNaN y then
+      nan
+    else if y > x then
+      y
+    else
+      x
+
+  let minimum x y =
+    if isNaN x || isNaN y then
+      nan
+    else if y < x then
+      y
+    else
+      x
+
+  let hypotenuse x y = squareRoot (x * x + y * y)
+
+  let degrees n = n * (pi / 180.0)
+
+  let radians = identity
+
+  let turns n = n * 2. * pi
+
+  let cos = Base.Float.cos
+
+  let acos = Base.Float.acos
+
+  let sin = Base.Float.sin
+
+  let asin = Base.Float.asin
+
+  let tan = Base.Float.tan
+
+  let atan = Base.Float.atan
+
+  let atan2 ~y ~x = Base.Float.atan2 y x
+
+  type direction = [
+    | `Zero
+    | `AwayFromZero
+    | `Up
+    | `Down
+    | `Closest of [
+      | `Zero
+      | `AwayFromZero
+      | `Up
+      | `Down
+      | `ToEven
+    ]
+  ]
+
+  let round ?(direction = (`Closest `Up)) n =
+    match direction with
+    | `Up | `Down | `Zero as dir -> Base.Float.round n ~dir
+    | `AwayFromZero -> (
+        if n < 0. then Base.Float.round n ~dir:`Down
+        else Base.Float.round n ~dir:`Up
+      )
+    | (`Closest `Zero) -> (
+        if n > 0. then Base.Float.round (n -. 0.5) ~dir:`Up
+        else Base.Float.round (n +. 0.5) ~dir:`Down
+      )
+    | `Closest `AwayFromZero -> (
+        if n > 0. then Base.Float.round (n +. 0.5) ~dir:`Down
+        else Base.Float.round (n -. 0.5) ~dir:`Up
+      )
+    | (`Closest `Down) -> (
+        Base.Float.round (n -. 0.5) ~dir:`Up
+      )
+    | (`Closest `Up) -> Base.Float.round_nearest n
+    | (`Closest `ToEven) -> Base.Float.round_nearest_half_to_even n
+
+  let floor = Base.Float.round_down
+
+  let ceiling = Base.Float.round_up
+
+  let truncate = Base.Float.round_towards_zero
+
+  let fromPolar (r, theta) = (r * cos theta, r * sin theta)
+
+  let from_polar = fromPolar
+
+  let toPolar (x, y) = (hypotenuse x y, atan2 ~x ~y)
+
+  let to_polar = toPolar
+
+  let fromInt = Base.Float.of_int
+
+  let from_int = fromInt
+
+  let toInt = Base.Float.iround_towards_zero
+
+  let to_int = toInt
+end
+
 module Int = struct
+  type t = int
+
+  let minimumValue = Base.Int.min_value
+
+  let minimum_value = minimumValue
+
+  let maximumValue = Base.Int.max_value
+
+  let maximum_value = maximumValue
+
+  let zero = 0
+
+  let one = 1
+
+  let add = (+)
+
+  let (+) = (+)
+
+  let subtract = (-)
+
+  let (-) = (-)
+
+  let multiply = ( * )
+
+  let ( * ) = multiply
+
+  let divide n ~by = n / by
+
+  let ( / ) = ( / )
+
+  let ( // ) = Base.Int.( // )
+
+  let power ~base ~exponent = Base.Int.(base ** exponent)
+
+  let ( ** ) = Base.Int.( ** )
+
   let negate = (~-)
+
+  let (~-) = (~-)
+
+  let modulo n ~by = n mod by
+
+  let remainder n ~by = Base.Int.rem n by
+
+  let maximum = Base.Int.max
+
+  let minimum = Base.Int.min
+
+  let absolute n = if n < 0 then n * (-1) else n
 
   let isEven n = n mod 2 = 0
 
   let is_even = isEven
 
-  let isOdd n = n mod 2 != 0
+  let isOdd n = n mod 2 <> 0
 
   let is_odd = isOdd
+
+  let clamp n ~lower ~upper =
+    if upper < lower then
+      raise (
+        Invalid_argument ("~lower:" ^ (Base.Int.to_string lower) ^ " must be less than or equal to ~upper:" ^ (Base.Int.to_string upper))
+      )
+    else
+      max lower (min upper n)
+
+  let inRange n ~lower ~upper =
+    if upper < lower then
+      raise (
+        Invalid_argument ("~lower:" ^ (Base.Int.to_string lower) ^ " must be less than or equal to ~upper:" ^ (Base.Int.to_string upper))
+      )
+    else
+      n >= lower && n < upper
+
+  let in_range = inRange
+
+  let toFloat = Base.Int.to_float
+
+  let to_float = toFloat
+
+  let toString = Base.Int.to_string
+
+  let to_string = toString
+
+  let fromString = int_of_string_opt
+
+  let from_string = fromString
 end
 
 module String = struct

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -728,34 +728,942 @@ module Char : sig
   val is_whitespace : char -> bool
 end
 
+module Float : sig
+  (** A module for working with {{: https://en.wikipedia.org/wiki/Floating-point_arithmetic } floating-point numbers}. Valid syntax for [float]s includes:
+    {[
+      0.
+      0.0
+      42.
+      42.0
+      3.14
+      0.1234
+      123_456.123_456
+      6.022e23   (* = (6.022 * 10^23) *)
+      6.022e+23  (* = (6.022 * 10^23) *)
+      1.602e−19  (* = (1.602 * 10^-19) *)
+      1e3        (* = (1 * 10 ** 3) = 1000. *)
+    ]}
+
+    Without opening this module you can use the [.] suffixed operators e.g
+
+    {[ 1. +. 2. /. 0.25 *. 2. = 17. ]}
+
+    But by opening this module locally you can use the un-suffixed operators
+
+    {[Float.((10.0 - 1.5 / 0.5) ** 3.0) = 2401.0]}
+
+    {b Historical Note: } The particular details of floats (e.g. [NaN]) are
+    specified by {{: https://en.wikipedia.org/wiki/IEEE_754 } IEEE 754 } which is literally hard-coded into almost all
+    CPUs in the world.
+  *)
+
+  type t = float
+
+  (** {1 Constants} *)
+
+  val zero : t
+  (** The literal [0.0] as a named value *)
+
+  val one : t
+  (** The literal [1.0] as a named value *)
+
+  val nan : t
+  (** [NaN] as a named value. NaN stands for {{: https://en.wikipedia.org/wiki/NaN } not a number}.
+
+      {b Note } comparing values with {!Float.nan} will {b always return } [false] even if the value you are comparing against is also [NaN].
+
+      e.g
+
+      {[
+let isNotANmber x = Float.(x = nan) in
+isNotANumber nan = false
+
+
+]}
+
+      For detecting [Nan] you should use {!Float.isNaN}
+
+  *)
+
+  val infinity : t
+  (** Positive {{: https://en.wikipedia.org/wiki/IEEE_754-1985#Positive_and_negative_infinity } infinity }
+
+    {[Float.log ~base:10.0 0.0 = Float.infinity]} *)
+
+  val negativeInfinity : t
+  (** Negative infinity, see {!Float.infinity} *)
+
+  val negative_infinity : t
+
+  val e : t
+  (** An approximation of {{: https://en.wikipedia.org/wiki/E_(mathematical_constant) } Euler's number }. *)
+
+  val pi : t
+  (** An approximation of {{: https://en.wikipedia.org/wiki/Pi } pi }. *)
+
+  (** {1 Basic arithmetic and operators} *)
+
+  val add : t -> t -> t
+  (** Addition for floating point numbers.
+
+    {[Float.add 3.14 3.14 = 6.28]}
+
+    {[Float.(3.14 + 3.14 = 6.28)]}
+
+    Although [int]s and [float]s support many of the same basic operations such as
+    addition and subtraction you {b cannot} [add] an [int] and a [float] directly which
+    means you need to use functions like {!Int.toFloat} or {!Float.roundToInt} to convert both values to the same type.
+
+    So if you needed to add a {!List.length} to a [float] for some reason, you
+    could:
+
+    {[Float.add 3.14 (Int.toFloat (List.length [1,2,3])) = 6.14]}
+
+    or
+
+    {[Float.roundToInt 3.14 + List.length [1,2,3] = 6]}
+
+    Languages like Java and JavaScript automatically convert [int] values
+    to [float] values when you mix and match. This can make it difficult to be sure
+    exactly what type of number you are dealing with and cause unexpected behavior.
+
+    OCaml has opted for a design that makes all conversions explicit.
+  *)
+
+  val ( + ) : t -> t -> t
+  (** See {!Float.add} *)
+
+  val subtract : t -> t -> t
+  (** Subtract numbers
+    {[Float.subtract 4.0 3.0 = 1.0]}
+
+    Alternatively the [-] operator can be used:
+
+    {[Float.(4.0 - 3.0) = 1.0]}
+  *)
+
+  val ( - ) : t -> t -> t
+  (** See {!Float.subtract} *)
+
+  val multiply : t -> t -> t
+  (** Multiply numbers like
+
+    {[Float.multiply 2.0 7.0 = 14.0]}
+
+    Alternatively the operator [*] can be used:
+
+    {[Float.(2.0 * 7.0) = 14.0]}
+  *)
+
+  val ( * ) : t -> t -> t
+  (** See {!Float.multiply} *)
+
+  val divide : t -> by:t -> t
+  (** Floating-point division:
+
+    {[Float.divide 3.14 ~by:2.0 = 1.57]}
+
+    Alternatively the [/] operator can be used:
+
+    {[Float.(3.14 / 2.0) = 1.57]} *)
+
+  val ( / ) : t -> t -> t
+  (** See {!Float.divide} *)
+
+  val power : base:t -> exponent:t -> t
+  (** Exponentiation, takes the base first, then the exponent.
+
+    {[Float.power ~base:7.0 ~exponent:3.0 = 343.0]}
+
+    Alternatively the [**] operator can be used:
+
+    {[Float.(7.0 ** 3.0) = 343.0]}
+  *)
+
+  val ( ** ) : t -> t -> t
+  (** See {!Float.power} *)
+
+  val negate : t -> t
+  (** Flips the 'sign' of a [float] so that positive floats become negative and negative integers become positive. Zero stays as it is.
+
+    {[Float.negate 8 = (-8)]}
+
+    {[Float.negate (-7) = 7]}
+
+    {[Float.negate 0 = 0]}
+
+    Alternatively an operator is available:
+
+    {[Float.(~- 4.0) = (-4.0)]}
+  *)
+
+  val (~-) : t -> t
+  (** See {!Float.negate} *)
+
+  val absolute : t -> t
+  (** Get the {{: https://en.wikipedia.org/wiki/Absolute_value } absolute value} of a number.
+
+    {[Float.absolute 8. = 8.]}
+
+    {[Float.absolute (-7) = 7]}
+
+    {[Float.absolute 0 = 0]}
+  *)
+
+  val maximum : t -> t -> t
+   (** Returns the larger of two [float]s, if both arguments are equal, returns the first argument
+
+    {[Float.maximum 7. 9. = 9.]}
+
+    {[Float.maximum (-4.) (-1.) = (-1.)]}
+
+    If either (or both) of the arguments are [NaN], returns [NaN]
+
+    {[Float.(isNaN (maximum 7. nan) = true]}
+  *)
+
+  val minimum : t -> t -> t
+  (** Returns the smaller of two [float]s, if both arguments are equal, returns the first argument
+
+    {[Float.minimum 7.0 9.0 = 7.0]}
+
+    {[Float.minimum (-4.0) (-1.0) = (-4.0)]}
+
+    If either (or both) of the arguments are [NaN], returns [NaN]
+
+    {[Float.(isNaN (minimum 7. nan) = true]}
+  *)
+
+  val clamp : t -> lower:t -> upper:t -> t
+  (** Clamps [n] within the inclusive [lower] and [upper] bounds.
+
+    {[Float.clamp ~lower:0. ~upper:8. 5. = 5.]}
+
+    {[Float.clamp ~lower:0. ~upper:8. 9. = 8.]}
+
+    {[Float.clamp ~lower:(-10.) ~upper:(-5.) 5. = -5.]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  (** {1 Fancier math} *)
+
+  val squareRoot : t -> t
+  (** Take the square root of a number.
+    {[Float.squareRoot 4.0 = 2.0]}
+
+    {[Float.squareRoot 9.0 = 3.0]}
+
+    [squareRoot] returns [NaN] when its argument is negative. See {!Float.nan} for more.
+  *)
+
+  val square_root : t -> t
+
+  val log : t -> base:t -> t
+  (** Calculate the logarithm of a number with a given base.
+
+    {[Float.log ~base:10. 100. = 2.]}
+
+    {[Float.log ~base:2. 256. = 8.]}
+  *)
+
+  (** {1 Checks} *)
+
+  val isNaN : t -> bool
+  (** Determine whether a float is an undefined or unrepresentable number.
+
+    {[Float.isNaN (0.0 / 0.0) = true]}
+
+    {[Float.(isNaN (squareRoot (-1.0)) = true]}
+
+    {[Float.isNaN (1.0 / 0.0) = false  (* Float.infinity {b is} a number *)]}
+
+    {[Float.isNaN 1. = false]}
+
+    {b Note } this function is more useful than it might seem since [NaN] {b does not } equal [Nan]:
+
+    {[Float.(nan = nan) = false]}
+  *)
+
+  val is_nan : t -> bool
+
+  val isFinite : t -> bool
+  (** Determine whether a float is finite number. True for any float except [Infinity], [-Infinity] or [NaN]
+
+    {[Float.isFinite (0. / 0.) = false]}
+
+    {[Float.(isFinite (squareRoot (-1.)) = false]}
+
+    {[Float.isFinite (1. / 0.) = false]}
+
+    {[Float.isFinite 1. = true]}
+
+    {[Float.(isFinite nan) = false]}
+
+    Notice that [NaN] is not finite!
+
+    For a [float] [n] to be finite implies that [Float.(not (isInfinite n || isNaN n))] evaluates to [true].
+  *)
+
+  val is_finite : t -> bool
+
+  val isInfinite : t -> bool
+  (** Determine whether a float is positive or negative infinity.
+
+    {[Float.isInfinite (0. / 0.) = false]}
+
+    {[Float.(isInfinite (squareRoot (-1.)) = false]}
+
+    {[Float.isInfinite (1. / 0.) = true]}
+
+    {[Float.isInfinite 1. = false]}
+
+    {[Float.(isInfinite nan) = false]}
+
+    Notice that [NaN] is not infinite!
+
+    For a [float] [n] to be finite implies that [Float.(not (isInfinite n || isNaN n))] evaluates to [true].
+  *)
+
+  val is_infinite : t -> bool
+
+  val inRange : t -> lower:t -> upper:t -> bool
+  (** Checks if [n] is between [lower] and up to, but not including, [upper].
+    If [lower] is not specified, it's set to to [0.0].
+
+    {[Float.inRange ~lower:2. ~upper:4. 3. = true]}
+
+    {[Float.inRange ~lower:1. ~upper:2. 2. = false]}
+
+    {[Float.inRange ~lower:5.2 ~upper:7.9 9.6 = false]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val in_range : t -> lower:t -> upper:t -> bool
+
+  (** {1 Angles} *)
+
+  val hypotenuse : t -> t -> t
+  (** [hypotenuse x y] returns the length of the hypotenuse of a right-angled triangle with sides of length [x] and [y], or, equivalently, the distance of the point [(x, y)] to [(0, 0)].
+
+    {[Float.hypotenuse 3. 4. = 5.]}
+  *)
+
+  val degrees : t -> t
+  (** Converts an angle in {{: https://en.wikipedia.org/wiki/Degree_(angle) } degrees} to {!Float.radians}.
+
+    {[Float.degrees 180. = v]}
+  *)
+
+  val radians : t -> t
+  (** Convert a {!Float.t} to {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(radians pi) = 3.141592653589793]}
+
+    {b Note } This function doesn't actually do anything to its argument, but can be useful to indicate intent when inter-mixing angles of different units within the same function.
+  *)
+
+  val turns : t -> t
+  (** Convert an angle in {{: https://en.wikipedia.org/wiki/Turn_(geometry) } turns } into {!Float.radians}.
+
+    One turn is equal to 360°.
+
+    {[Float.(turns (1. / 2.)) = pi]}
+
+    {[Float.(turns 1. = degrees 360.)]}
+  *)
+
+  (** {1 Polar coordinates} *)
+
+  val fromPolar : (float * float) -> (float * float)
+  (** Convert {{: https://en.wikipedia.org/wiki/Polar_coordinate_system } polar coordinates } (r, θ) to {{: https://en.wikipedia.org/wiki/Cartesian_coordinate_system } Cartesian coordinates } (x,y).
+
+    {[Float.(fromPolar (squareRoot 2., degrees 45.)) = (1., 1.)]}
+  *)
+
+  val from_polar : (float * float) -> (float * float)
+
+  val toPolar : (float * float) -> (float * float)
+  (** Convert {{: https://en.wikipedia.org/wiki/Cartesian_coordinate_system } Cartesian coordinates } (x,y) to {{: https://en.wikipedia.org/wiki/Polar_coordinate_system } polar coordinates } (r, θ).
+
+    {[Float.toPolar (3.0, 4.0) = (5.0, 0.9272952180016122)]}
+
+    {[Float.toPolar (5.0, 12.0) = (13.0, 1.1760052070951352)]}
+  *)
+
+  val to_polar : (float * float) -> (float * float)
+
+  val cos : t -> t
+  (** Figure out the cosine given an angle in {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(cos (degrees 60.)) = 0.5000000000000001]}
+
+    {[Float.(cos (radians (pi / 3.))) = 0.5000000000000001]}
+  *)
+
+  val acos : t -> t
+  (** Figure out the arccosine for [adjacent / hypotenuse] in {{: https://en.wikipedia.org/wiki/Radian } radians }:
+
+    {[Float.(acos (radians 1.0 / 2.0)) = Float.radians 1.0471975511965979 (* 60° or pi/3 radians *)]}
+  *)
+
+  val sin : t -> t
+  (** Figure out the sine given an angle in {{: https://en.wikipedia.org/wiki/Radian } radians }.
+
+    {[Float.(sin (degrees 30.)) = 0.49999999999999994]}
+
+    {[Float.(sin (radians (pi / 6.)) = 0.49999999999999994]}
+  *)
+
+  val asin : t -> t
+  (** Figure out the arcsine for [opposite / hypotenuse] in {{: https://en.wikipedia.org/wiki/Radian } radians }:
+
+    {[Float.(asin (1.0 / 2.0)) = 0.5235987755982989 (* 30° or pi / 6 radians *)]}
+  *)
+
+  val tan : t -> t
+  (** Figure out the tangent given an angle in radians.
+
+    {[Float.(tan (degrees 45.)) = 0.9999999999999999]}
+
+    {[Float.(tan (radians (pi / 4.)) = 0.9999999999999999]}
+
+    {[Float.(tan (pi / 4.)) = 0.9999999999999999]}
+  *)
+
+  val atan : t -> t
+  (** This helps you find the angle (in radians) to an [(x, y)] coordinate, but
+    in a way that is rarely useful in programming.
+
+    {b You probably want } {!atan2} instead!
+
+    This version takes [y / x] as its argument, so there is no way to know whether
+    the negative signs comes from the [y] or [x] value. So as we go counter-clockwise
+    around the origin from point [(1, 1)] to [(1, -1)] to [(-1,-1)] to [(-1,1)] we do
+    not get angles that go in the full circle:
+
+    {[Float.atan (1. /. 1.) = 0.7853981633974483  (* 45° or pi/4 radians *)]}
+
+    {[Float.atan (1. /. -1.) = -0.7853981633974483  (* 315° or 7 * pi / 4 radians *)]}
+
+    {[Float.atan (-1. /. -1.) = 0.7853981633974483 (* 45° or pi/4 radians *)]}
+
+    {[Float.atan (-1. /.  1.) = -0.7853981633974483 (* 315° or 7 * pi/4 radians *)]}
+
+    Notice that everything is between [pi / 2] and [-pi/2]. That is pretty useless
+    for figuring out angles in any sort of visualization, so again, check out
+    {!Float.atan2} instead!
+  *)
+
+  val atan2 : y:t -> x:t -> t
+  (** This helps you find the angle (in radians) to an [(x, y)] coordinate. So rather than saying [Float.(atan (y / x))] you can [Float.atan2 ~y ~x] and you can get a full range of angles:
+
+    {[Float.atan2 ~y:1. ~x:1. = 0.7853981633974483  (* 45° or pi/4 radians *)]}
+
+    {[Float.atan2 ~y:1. ~x:(-1.) = 2.3561944901923449  (* 135° or 3 * pi/4 radians *)]}
+
+    {[Float.atan2 ~y:(-1.) ~x:(-1.) = -(2.3561944901923449) (* 225° or 5 * pi/4 radians *)]}
+
+    {[Float.atan2 ~y:(-1.) ~x:1.) = -(0.7853981633974483) (* 315° or 7 * pi/4 radians *)]}
+  *)
+
+  (** {1 Conversion} *)
+
+  type direction = [
+    | `Zero
+    | `AwayFromZero
+    | `Up
+    | `Down
+    | `Closest of [
+      | `Zero
+      | `AwayFromZero
+      | `Up
+      | `Down
+      | `ToEven
+    ]
+  ]
+
+  val round : ?direction:direction -> t ->  t
+  (** Round a number, by default to the to the closest [int] with halves rounded [`Up] (towards positive infinity)
+
+    {[
+Float.round 1.2 = 1.0
+Float.round 1.5 = 2.0
+Float.round 1.8 = 2.0
+Float.round -1.2 = -1.0
+Float.round -1.5 = -1.0
+Float.round -1.8 = -2.0
+    ]}
+
+    Other rounding strategies are available by using the optional [~direction] label.
+
+    {2 Towards zero}
+
+    {[
+Float.round ~direction:`Zero 1.2 = 1.0
+Float.round ~direction:`Zero 1.5 = 1.0
+Float.round ~direction:`Zero 1.8 = 1.0
+Float.round ~direction:`Zero (-1.2) = -1.0
+Float.round ~direction:`Zero (-1.5) = -1.0
+Float.round ~direction:`Zero (-1.8) = -1.0
+    ]}
+
+    {2 Away from zero}
+
+    {[
+Float.round ~direction:`AwayFromZero 1.2 = 1.0
+Float.round ~direction:`AwayFromZero 1.5 = 1.0
+Float.round ~direction:`AwayFromZero 1.8 = 1.0
+Float.round ~direction:`AwayFromZero (-1.2) = -1.0
+Float.round ~direction:`AwayFromZero (-1.5) = -1.0
+Float.round ~direction:`AwayFromZero (-1.8) = -1.0
+    ]}
+
+    {2 Towards infinity}
+
+    This is also known as {!Float.ceiling}
+
+    {[
+Float.round ~direction:`Up 1.2 = 1.0
+Float.round ~direction:`Up 1.5 = 1.0
+Float.round ~direction:`Up 1.8 = 1.0
+Float.round ~direction:`Up (-1.2) = -1.0
+Float.round ~direction:`Up (-1.5) = -1.0
+Float.round ~direction:`Up (-1.8) = -1.0
+    ]}
+
+    {2 Towards negative infinity}
+
+    This is also known as {!Float.floor}
+
+    {[List.map  ~f:(Float.round ~direction:`Down) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -2.0; 1.0 1.0 1.0]]}
+
+    {2 To the closest integer}
+
+    Rounding a number [x] to the closest integer requires some tie-breaking for when the [fraction] part of [x] is exactly [0.5].
+
+    {3 Halves rounded towards zero}
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `AwayFromZero)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -1.0; -1.0; 1.0 1.0 2.0]]}
+
+    {3 Halves rounded away from zero}
+
+    This method is often known as {b commercial rounding }
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `AwayFromZero)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -1.0; 1.0 2.0 2.0]]}
+
+    {3 Halves rounded down}
+
+    {[List.map  ~f:(Float.round ~direction:(`Closest `Down)) [-1.8; -1.5; -1.2; 1.2; 1.5; 1.8] = [-2.0; -2.0; -1.0; 1.0 1.0 2.0]]}
+
+    {3 Halves rounded up}
+
+    This is the default.
+
+    [Float.round 1.5] is the same as [Float.round ~direction:(`Closest `Up) 1.5]
+
+    {3 Halves rounded towards the closest even number}
+
+    This tie-breaking rule is the default rounding mode using in
+
+    {[Float.round ~direction:(`Closest `ToEven) -1.5 = -2.0]}
+
+    {[Float.round ~direction:(`Closest `ToEven) -2.5 = -2.0]}
+  *)
+
+  val floor : t -> t
+  (** Floor function, equivalent to [Float.round ~direction:`Down].
+
+    {[Float.floor 1.2 = 1.0]}
+
+    {[Float.floor 1.5 = 1.0]}
+
+    {[Float.floor 1.8 = 1.0]}
+
+    {[Float.floor -1.2 = -2.0]}
+
+    {[Float.floor -1.5 = -2.0]}
+
+    {[Float.floor -1.8 = -2.0]}
+  *)
+
+  val ceiling : t -> t
+  (** Ceiling function, equivalent to [Float.round ~direction:`Up].
+
+    {[Float.ceiling 1.2 = 2.0]}
+
+    {[Float.ceiling 1.5 = 2.0]}
+
+    {[Float.ceiling 1.8 = 2.0]}
+
+    {[Float.ceiling -1.2 = (-1.0)]}
+
+    {[Float.ceiling -1.5 = (-1.0)]}
+
+    {[Float.ceiling -1.8 = (-1.0)]}
+  *)
+
+  val truncate : t -> t
+  (** Ceiling function, equivalent to [Float.round ~direction:`Zero].
+
+    {[Float.truncate 1.0 = 1]}
+
+    {[Float.truncate 1.2 = 1]}
+
+    {[Float.truncate 1.5 = 1]}
+
+    {[Float.truncate 1.8 = 1]}
+
+    {[Float.truncate (-1.2) = -1]}
+
+    {[Float.truncate (-1.5) = -1]}
+
+    {[Float.truncate (-1.8) = -1]}
+  *)
+
+  val fromInt : int -> float
+  (** Convert an [int] to a [float]
+
+    {[Float.fromInt 5 = 5.0]}
+
+    {[Float.fromInt 0 = 0.0]}
+
+    {[Float.fromInt -7 = -7.0]}
+  *)
+
+  val from_int : int -> float
+
+  val toInt : t ->  int option
+  (** Converts a [float] to an {!Int} by {b ignoring the decimal portion}. See {!Float.truncate} for examples.
+
+    Returns [None] when trying to round a [float] which can't be represented as an [int] such as {!Float.nan} or {!Float.infinity} or numbers which are too large or small.
+
+    {[Float.(toInt nan) = None]}
+
+    {[Float.(toInt infinity) = None]}
+
+    You probably want to use some form of {!Float.round} prior to using this function.
+
+    {[Float.(round 1.6 |> toInt) = Some 2]}
+  *)
+
+  val to_int : t ->  int option
+end
+
 module Int : sig
-  val negate : int -> int
-  (**
-    [Int.negate 8 = (-8)]
+  (** The platform-dependant {{: https://en.wikipedia.org/wiki/Integer } signed } {{: https://en.wikipedia.org/wiki/Integer } integer} type. An [int] is a whole number.
+    Valid syntax for [int]s includes:
+    {[
+      0
+      42
+      9000
+      1_000_000
+      1_000_000
+      0xFF (* 255 in hexadecimal *)
+      0x000A (* 10 in hexadecimal *)
+    ]}
 
-    [Int.negate (-7) = 7]
+    {b Note:} The number of bits used for an [int] is platform dependent.
 
-    [Int.negate 0 = 0] *)
+    When targeting native OCaml uses 31-bits on a 32-bit platforms and 63-bits on a 64-bit platforms
+    which means that [int] math is well-defined in the range [-2 ** 30] to [2 ** 30 - 1] for 32bit platforms [-2 ** 62] to [2 ** 62 - 1] for 64bit platforms.
 
-  val isEven : int -> bool
-  (**
-    [Int.isEven 8 = true]
+    You can read about the reasons for OCamls unusual integer sizes {{: https://v1.realworldocaml.org/v1/en/html/memory-representation-of-values.html} here }.
 
-    [Int.isEven 7 = false]
+    When targeting JavaScript, that range is [-2 ** 53] to [2 ** 53 - 1].
 
-    [Int.isEven 0 = true] *)
+    Outside of that range, the behavior is determined by the compilation target.
 
-  val is_even : int -> bool
+    [int]s are subject to {{: https://en.wikipedia.org/wiki/Integer_overflow } overflow }, meaning that [Int.maximumValue + 1 = Int.minimumValue].
 
-  val isOdd : int -> bool
-    (**
-    [Int.isOdd 7 = true]
+    {e Historical Note: } The name [int] comes from the term {{: https://en.wikipedia.org/wiki/Integer } integer}). It appears
+    that the [int] abbreviation was introduced in the programming language ALGOL 68.
 
-    [Int.isOdd 8 = false]
+    Today, almost all programming languages use this abbreviation.
+  *)
 
-    [Int.isOdd 0 = false] *)
+  type t = int
 
-  val is_odd : int -> bool
+  (** {1 Constants } *)
+
+  val zero : t
+  (** The literal [0] as a named value *)
+
+  val one : t
+  (** The literal [1] as a named value *)
+
+  val maximumValue : t
+  (** The maximum representable [int] on the current platform *)
+
+  val maximum_value : t
+
+  val minimumValue : t
+  (** The minimum representable [int] on the current platform *)
+
+  val minimum_value : t
+
+  (** {1 Operators }
+    {b Note } You do not need to open the {!Int} module to use the {!( + )}, {!( - )}, {!( * )} or {!( / )} operators, these are available as soon as you [open Tablecloth]
+  *)
+
+  val add : t -> t -> t
+  (** Add two {!Int} numbers.
+
+    {[Int.add 3002 4004 = 7006]}
+
+    Or using the globally available operator:
+
+    {[3002 + 4004 = 7006]}
+
+    You {e cannot } add an [int] and a [float] directly though.
+
+    See {!Float.add} for why, and how to overcome this limitation.
+  *)
+
+  val ( + ) : t -> t -> t
+  (** See {!Int.add} *)
+
+  val subtract : t -> t -> t
+  (** Subtract numbers
+    {[Int.subtract 4 3 = 1]}
+
+    Alternatively the operator can be used:
+
+    {[4 - 3 = 1]}
+  *)
+
+  val ( - ) : t -> t -> t
+  (** See {!Int.subtract} *)
+
+  val multiply : t -> t -> t
+  (** Multiply [int]s like
+
+    {[Int.multiply 2 7 = 14]}
+
+    Alternatively the operator can be used:
+
+    {[(2 * 7) = 14]}
+  *)
+
+  val ( * ) : t -> t -> t
+  (** See {!Int.multiply} *)
+
+  val divide : t -> by:t -> t
+  (** Integer division:
+
+    {[Int.divide 3 ~by:2 = 1]}
+
+    {[27 / 5 = 5]}
+
+    Notice that the remainder is discarded.
+
+    Throws [Division_by_zero] when the [by] (the divisor) is [0].
+  *)
+
+  val ( / ) : t -> t -> t
+  (** See {!Int.divide} *)
+
+  val ( // ) : t -> t -> float
+  (** Floating point division
+    {[3 // 2 = 1.5]}
+
+    {[27 // 5 = 5.25]}
+
+    {[8 // 4 = 2.0]}
+  *)
+
+  val power : base:t -> exponent:t -> t
+  (** Exponentiation, takes the base first, then the exponent.
+
+    {[Int.power ~base:7 ~exponent:3 = 343]}
+
+    Alternatively the [**] operator can be used:
+
+    {[7 ** 3 = 343]}
+  *)
+
+  val ( ** ) : t -> t -> t
+  (** See {!Int.power} *)
+
+  val negate : t -> t
+  (** Flips the 'sign' of an integer so that positive integers become negative and negative integers become positive. Zero stays as it is.
+
+    {[Int.negate 8 = (-8)]}
+
+    {[Int.negate (-7) = 7]}
+
+    {[Int.negate 0 = 0]}
+
+    Alternatively the operator can be used:
+
+    {[~-(7) = (-7)]}
+  *)
+
+  val (~-) : t -> t
+  (** See {!Int.negate} *)
+
+  val absolute : t -> t
+  (** Get the {{: https://en.wikipedia.org/wiki/Absolute_value } absolute value } of a number.
+
+    {[Int.absolute 8 = 8]}
+
+    {[Int.absolute (-7) = 7]}
+
+    {[Int.absolute 0 = 0]} *)
+
+  val modulo : t -> by:t -> t
+  (** Perform {{: https://en.wikipedia.org/wiki/Modular_arithmetic } modular arithmetic }.
+
+    If you intend to use [modulo] to detect even and odd numbers consider using {!Int.isEven} or {!Int.isOdd}.
+
+    {[Int.modulo ~by:2 0 = 0]}
+
+    {[Int.modulo ~by:2 1 = 1]}
+
+    {[Int.modulo ~by:2 2 = 0]}
+
+    {[Int.modulo ~by:2 3 = 1]}
+
+    Our [modulo] function works in the typical mathematical way when you run into negative numbers:
+
+    {[
+      List.map ~f:(Int.modulo ~by:4) [(-5); (-4); -3; -2; -1;  0;  1;  2;  3;  4;  5 ] =
+        [3; 0; 1; 2; 3; 0; 1; 2; 3; 0; 1]
+    ]}
+
+    Use {!Int.remainder} for a different treatment of negative numbers.
+  *)
+
+  val remainder : t -> by:t -> t
+  (** Get the remainder after division. Here are bunch of examples of dividing by four:
+
+    {[
+      List.map ~f:(Int.remainder ~by:4) [(-5); (-4); (-3); (-2); (-1); 0; 1; 2; 3; 4; 5] =
+        [(-1); 0; (-3); (-2); (-1); 0; 1; 2; 3; 0; 1]
+    ]}
+
+
+    Use {!Int.modulo} for a different treatment of negative numbers.
+  *)
+
+  val maximum : t -> t -> t
+  (** Returns the larger of two [int]s
+
+    {[Int.maximum 7 9 = 9]}
+
+    {[Int.maximum (-4) (-1) = (-1)]} *)
+
+  val minimum : t -> t -> t
+  (** Returns the smaller of two [int]s
+
+    {[Int.minimum 7 9 = 7]}
+
+    {[Int.minimum (-4) (-1) = (-4)]} *)
+
+  (** {1 Checks} *)
+
+  val isEven : t -> bool
+  (** Check if an [int] is even
+
+    {[Int.isEven 8 = true]}
+
+    {[Int.isEven 7 = false]}
+
+    {[Int.isEven 0 = true]} *)
+
+  val is_even : t -> bool
+
+  val isOdd : t -> bool
+  (** Check if an [int] is odd
+
+    {[Int.isOdd 7 = true]}
+
+    {[Int.isOdd 8 = false]}
+
+    {[Int.isOdd 0 = false]} *)
+
+  val is_odd : t -> bool
+
+  val clamp : t -> lower:t -> upper:t -> t
+  (** Clamps [n] within the inclusive [lower] and [upper] bounds.
+
+    {[Int.clamp ~lower:0 ~upper:8 5 = 5]}
+
+    {[Int.clamp ~lower:0 ~upper:8 9 = 8]}
+
+    {[Int.clamp ~lower:(-10) ~upper:(-5) 5 = (-5)]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val inRange : t -> lower:t -> upper:t -> bool
+  (** Checks if [n] is between [lower] and up to, but not including, [upper].
+
+    {[Int.inRange ~lower:2 ~upper:4 3 = true]}
+
+    {[Int.inRange ~lower:5 ~upper:8 4 = false]}
+
+    {[Int.inRange ~lower:(-6) ~upper:(-2) (-3) = true]}
+
+    Throws an [Invalid_argument] exception if [lower > upper]
+  *)
+
+  val in_range : t -> lower:t -> upper:t -> bool
+
+  (** {1 Conversion } *)
+
+  val toFloat : t -> float
+  (** Convert an integer into a float. Useful when mixing {!Int} and {!Float} values like this:
+
+    {[
+let halfOf (number : int) : float =
+  Float.((Int.toFloat number) / 2)
+
+halfOf 7 = 3.5
+    ]}
+    Note that locally opening the {!Float} module here allows us to use the floating point division operator
+  *)
+
+  val to_float : t -> float
+
+  val toString : t -> string
+  (** Convert an [int] into a [string] representation.
+
+    {[Int.toString 3 = "3"]}
+
+    {[Int.toString (-3) = "-3"]}
+
+    {[Int.toString 0 = "0"]}
+
+    Guarantees that
+
+    {[Int.(fromString (toString n)) = Some n ]}
+ *)
+
+  val to_string : t -> string
+
+  val fromString : string -> t option
+  (** Attempt to parse a [string] into a [int].
+
+    {[Int.fromString "0" = Some 0.]}
+
+    {[Int.fromString "42" = Some 42.]}
+
+    {[Int.fromString "-3" = Some (-3)]}
+
+    {[Int.fromString "123_456" = Some 123_456]}
+
+    {[Int.fromString "0xFF" = Some 255]}
+
+    {[Int.fromString "0x00A" = Some 10]}
+
+    {[Int.fromString "Infinity" = None]}
+
+    {[Int.fromString "NaN" = None]}
+  *)
+
+  val from_string : string -> t option
 end
 
 module Tuple2 : sig
@@ -831,18 +1739,18 @@ module Tuple2 : sig
       [Tuple2.swap ("stressed", 16) = (16, "stressed")]
   *)
 
-  val curry : (('a * 'b) -> 'c) -> 'a -> 'b -> 'c 
+  val curry : (('a * 'b) -> 'c) -> 'a -> 'b -> 'c
   (** [curry f] takes a function [f] which takes a single argument of a tuple ['a * 'b] and returns a function which takes two arguments that can be partially applied.
 
       [let squareArea (width, height) = width * height]
-    
+
       [let curriedArea : float -> float -> float = curry squareArea]
 
       [let heights = [3, 4, 5]]
 
       [List.map widths ~f:(curriedArea 4) = [12; 16; 20]]
   *)
-  
+
   val uncurry : ('a -> 'b -> 'c) -> ('a * 'b) -> 'c
   (** [uncurry f] takes a function [f] which takes two arguments and returns a function which takes a single argument of a 2-tuple
 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -1,7 +1,7 @@
 open Tablecloth
 module AT = Alcotest
 
-let trio a b c = 
+let trio a b c =
   let eq (a1, b1, c1) (a2, b2, c2) = AT.equal a a1 a2 && AT.equal b b1 b2 && AT.equal c c1 c2 in
   let pp ppf (x, y, z) = Fmt.pf ppf "@[<1>(@[%a@],@ @[%a@],@ @[%a@])@]" (AT.pp a) x (AT.pp b) y (AT.pp c) z in
   AT.testable pp eq
@@ -63,27 +63,27 @@ let t_Array () =
   AT.check (AT.option AT.int) "get - returns None for an out of bounds index" (Array.get ~index:5 [|0; 1; 2|]) None;
   AT.check (AT.option AT.int) "get - returns None for an empty array" (Array.get ~index:0 [||]) None;
 
-  AT.check 
-    (AT.array AT.int) 
-    "set - can be partially applied to set an element" 
+  AT.check
+    (AT.array AT.int)
+    "set - can be partially applied to set an element"
     (
       let setZero = Array.set ~value:0 in
       let numbers = [|1;2;3|] in
       setZero numbers ~index:2;
       setZero numbers ~index:1;
-      numbers 
+      numbers
     )
     [|1;0;0|];
 
-  AT.check 
-    (AT.array AT.string) 
-    "set - can be partially applied to set an index" 
+  AT.check
+    (AT.array AT.string)
+    "set - can be partially applied to set an index"
     (
       let setZerothElement = Array.set ~index:0 in
-      let animals = [|"ant"; "bat"; "cat"|] in    
-      setZerothElement animals ~value:"antelope";    
+      let animals = [|"ant"; "bat"; "cat"|] in
+      setZerothElement animals ~value:"antelope";
       animals
-    ) 
+    )
     [|"antelope"; "bat"; "cat"|];
 
   AT.check AT.int "sum - equals zero for an empty array" (Array.sum [||]) 0;
@@ -100,16 +100,16 @@ let t_Array () =
 
   AT.check (AT.array AT.int) "map2 - works when the order of arguments to `f` is not important" (Array.map2 ~f:(+) [|1;2;3|] [|4;5;6|]) [|5;7;9|];
 
-  AT.check 
-    (AT.array (AT.pair AT.string AT.int)) 
-    "map2 - works when the order of `f` is important" 
-    (Array.map2 ~f:Tuple2.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8|]) 
+  AT.check
+    (AT.array (AT.pair AT.string AT.int))
+    "map2 - works when the order of `f` is important"
+    (Array.map2 ~f:Tuple2.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8|])
     [|("alice",2);("bob",5);("chuck",7)|];
 
-  AT.check 
-    (AT.array (trio AT.string AT.int AT.bool)) 
-    "map3" 
-    (Array.map3 ~f:Tuple3.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8;|] [|true; false; true; false|]) 
+  AT.check
+    (AT.array (trio AT.string AT.int AT.bool))
+    "map3"
+    (Array.map3 ~f:Tuple3.create [|"alice"; "bob"; "chuck"|] [|2; 5; 7; 8;|] [|true; false; true; false|])
     [|("alice", 2, true); ("bob", 5, false); ("chuck", 7, true)|];
 
   AT.check (AT.array AT.int) "flatMap" (Array.flatMap ~f:(fun n -> [|n; n|]) [|1; 2; 3|]) [|1; 1; 2; 2; 3; 3|];
@@ -130,9 +130,9 @@ let t_Array () =
 
   AT.check (AT.array AT.int) "concatenate" (Array.concatenate [|[|1; 2|]; [|3|]; [|4; 5|]|]) [|1; 2; 3; 4; 5|];
 
-  AT.check 
-    (AT.array AT.string) 
-    "intersperse - equals an array literal of the same value" 
+  AT.check
+    (AT.array AT.string)
+    "intersperse - equals an array literal of the same value"
     [|"turtles"; "on"; "turtles"; "on"; "turtles"|]
     (Array.intersperse ~sep:"on" [|"turtles"; "turtles"; "turtles"|]);
 
@@ -147,11 +147,11 @@ let t_Array () =
 
     AT.check (AT.array AT.int) "slice - should work with a negative `from`" (Array.slice ~from:(-1) array) [|4|];
 
-    Base.List.iter positiveArrayLengths ~f:(fun from -> 
+    Base.List.iter positiveArrayLengths ~f:(fun from ->
       AT.check (AT.array AT.int) "slice - should work when `from` >= `length`" (Array.slice ~from array) [||]
     );
 
-    Base.List.iter negativeArrayLengths ~f:(fun from -> 
+    Base.List.iter negativeArrayLengths ~f:(fun from ->
       AT.check (AT.array AT.int) "slice - should work when `from` <= negative `length`"  (Array.slice ~from array) array
     );
 
@@ -166,7 +166,7 @@ let t_Array () =
     Base.List.iter negativeArrayLengths ~f:(fun to_ ->
       AT.check (AT.array AT.int) "slice - should work when `to_` <= negative `length`"  (Array.slice ~from:0  ~to_ array) [||]
     );
-    
+
     AT.check (AT.array AT.int) "slice - should work when both `from` and `to_` are negative and `from` < `to_`" (Array.slice ~from:(-2)  ~to_:(-1) array) [|3|];
 
     AT.check (AT.array AT.int) "slice - works when `from` >= `to_`" (Array.slice ~from:(4)  ~to_:(3) array) [||];
@@ -184,43 +184,42 @@ let t_Array () =
 
   AT.check (AT.array AT.int) "reverse - empty array" (Array.reverse [||]) [||];
   AT.check (AT.array AT.int) "reverse - two elements" (Array.reverse [|0;1|]) [|1;0|];
-  AT.check 
-    (AT.array AT.int) 
-    "reverse - leaves the original array untouched" 
+  AT.check
+    (AT.array AT.int)
+    "reverse - leaves the original array untouched"
     (
       let array = [|0; 1; 2; 3;|] in
       let _reversedArray = Array.reverse array in
       array
-    ) 
+    )
     [|0; 1; 2; 3;|];
 
-  AT.check 
-    (AT.array AT.int) 
-    "reverseInPlace - alters an array in-place" 
+  AT.check
+    (AT.array AT.int)
+    "reverseInPlace - alters an array in-place"
     (
       let array = [|1;2;3|] in
       Array.reverseInPlace array;
       array
-    ) 
+    )
     [|3;2;1|];
 
-  AT.check 
-    (AT.array AT.int) 
+  AT.check
+    (AT.array AT.int)
     "forEach" (
       let index = ref 0 in
       let calledValues = [|0;0;0|] in
-    
-      Array.forEach [|1;2;3|] ~f:(fun value -> 
+
+      Array.forEach [|1;2;3|] ~f:(fun value ->
         Array.set calledValues ~index:!index ~value;
         index := !index + 1;
       );
-      
-      calledValues
-    ) 
-    [|1;2;3|];
-  
-  ()
 
+      calledValues
+    )
+    [|1;2;3|];
+
+  ()
 
 let t_Char () =
   AT.check AT.int "toCode" (Char.toCode 'a') 97;
@@ -250,12 +249,12 @@ let t_Char () =
   AT.check (AT.option AT.int) "toDigit - converts ASCII characters representing digits into integers" (Char.toDigit 'a') None;
 
   AT.check AT.bool "isLowercase - returns true for any lowercase character" (Char.isLowercase 'a') true;
-  AT.check AT.bool "isLowercase - returns false for all other characters" (Char.isLowercase '7') false;      
-  AT.check AT.bool "isLowercase - returns false for non-ASCII characters" (Char.isLowercase '\236') false;      
+  AT.check AT.bool "isLowercase - returns false for all other characters" (Char.isLowercase '7') false;
+  AT.check AT.bool "isLowercase - returns false for non-ASCII characters" (Char.isLowercase '\236') false;
 
   AT.check AT.bool "isUppercase - returns true for any uppercase character" (Char.isUppercase 'A') true;
-  AT.check AT.bool "isUppercase - returns false for all other characters" (Char.isUppercase '7') false;      
-  AT.check AT.bool "isUppercase - returns false for non-ASCII characters" (Char.isLowercase '\237') false;      
+  AT.check AT.bool "isUppercase - returns false for all other characters" (Char.isUppercase '7') false;
+  AT.check AT.bool "isUppercase - returns false for non-ASCII characters" (Char.isLowercase '\237') false;
 
   AT.check AT.bool "isLetter - returns true for any ASCII alphabet character" (Char.isLetter 'A') true;
   AT.check AT.bool "isLetter - returns false for all other characters" (Char.isLetter '\n') false;
@@ -265,14 +264,346 @@ let t_Char () =
   AT.check AT.bool "isDigit - returns false for all other characters" (Char.isDigit 'a') false;
 
   AT.check AT.bool "isAlphanumeric - returns true for any alphabet or digit character" (Char.isAlphanumeric 'A') true;
-  AT.check AT.bool "isAlphanumeric - returns false for all other characters" (Char.isAlphanumeric '?') false;      
+  AT.check AT.bool "isAlphanumeric - returns false for all other characters" (Char.isAlphanumeric '?') false;
 
   AT.check AT.bool "isPrintable - returns true for a printable character" (Char.isPrintable '~') true;
-  AT.check (AT.option AT.bool) "isPrintable - returns false for non-printable character" (Char.fromCode 31 |> Option.map ~f:Char.isPrintable ) (Some false);      
+  AT.check (AT.option AT.bool) "isPrintable - returns false for non-printable character" (Char.fromCode 31 |> Option.map ~f:Char.isPrintable ) (Some false);
 
   AT.check AT.bool "isWhitespace - returns true for any whitespace character" (Char.isWhitespace ' ') true;
-  AT.check AT.bool "isWhitespace - returns false for a non-whitespace character" (Char.isWhitespace 'a') false;      
+  AT.check AT.bool "isWhitespace - returns false for a non-whitespace character" (Char.isWhitespace 'a') false;
   ()
+
+let t_Float () = Float.(
+  AT.check (AT.float 0.)  "zero" zero 0.;
+
+  AT.check (AT.float 0.) "one" one 1.;
+
+  AT.check AT.bool "nan" (nan = nan) false;
+
+  AT.check AT.bool "infinity" (infinity > 0.) true;
+
+  AT.check AT.bool "negativeInfinity" (negativeInfinity < 0.) true;
+
+  AT.check AT.bool "equals zero" (0. = (-0.)) true;
+
+  AT.check (AT.float 0.) "add" (add 3.14 3.14) 6.28;
+  AT.check (AT.float 0.) "+" (3.14 + 3.14) 6.28;
+
+  AT.check (AT.float 0.) "subtract" (subtract 4. 3.) 1.;
+  AT.check (AT.float 0.) "-" (4. - 3.) 1.;
+
+  AT.check (AT.float 0.) "multiply" (multiply 2. 7.) 14.;
+  AT.check (AT.float 0.) "*" (2. * 7.) 14.;
+
+  AT.check (AT.float 0.) "divide" (divide 3.14 ~by:2.) 1.57;
+  AT.check (AT.bool) "divide by zero" (divide 3.14 ~by:0. = infinity) true;
+  AT.check (AT.bool) "divide by negative zero" (divide 3.14 ~by:(-0.) = negativeInfinity) true;
+  AT.check (AT.float 0.) "/" (3.14 / 2.) 1.57;
+
+  AT.check (AT.float 0.) "power" (power ~base:7. ~exponent:3.) 343.;
+  AT.check (AT.float 0.) "power - 0 base" (power ~base:0. ~exponent:3.) 0.;
+  AT.check (AT.float 0.) "power - 0 exponent" (power ~base:7. ~exponent:0.) 1.;
+  AT.check (AT.float 0.) "**" (7. ** 3.) 343.;
+
+  AT.check (AT.float 0.) "negate - positive number" (negate 8.) (-8.);
+  AT.check (AT.float 0.) "negate - negative number" (negate (-7.)) 7.;
+  AT.check (AT.float 0.) "negate - zero" (negate 0.) (-0.);
+  AT.check (AT.float 0.) "negate - ~-" (~- 7.) (-7.);
+
+  AT.check (AT.float 0.) "absolute - positive number" (absolute 8.) 8.;
+  AT.check (AT.float 0.) "absolute - negative number" (absolute (-7.)) 7.;
+  AT.check (AT.float 0.) "absolute - zero" (absolute 0.) 0.;
+
+  AT.check (AT.float 0.) "maximum - positive numbers" (maximum 7. 9.) 9.;
+  AT.check (AT.float 0.) "maximum - negative numbers" (maximum (-4.) (-1.)) (-1.);
+  AT.check (AT.bool) "maximum - nan" (maximum 7. nan |> isNaN) true;
+  AT.check (AT.bool) "maximum - infinity" (maximum 7. infinity = infinity) true;
+  AT.check (AT.float 0.) "maximum - negativeInfinity" (maximum 7. negativeInfinity) 7.;
+
+  AT.check (AT.float 0.) "minimum - positive numbers" (minimum 7. 9.) 7.;
+  AT.check (AT.float 0.) "minimum - negative numbers" (minimum (-4.) (-1.)) (-4.);
+  AT.check (AT.bool) "minimum - nan" (minimum 7. nan |> isNaN) true;
+  AT.check (AT.float 0.) "minimum - infinity" (minimum 7. infinity) 7.;
+  AT.check AT.bool "minimum - negativeInfinity" (minimum 7. negativeInfinity = negativeInfinity) true;
+
+  AT.check (AT.float 0.) "clamp - in range" (clamp ~lower:0. ~upper:8. 5.) 5.;
+  AT.check (AT.float 0.) "clamp - above range" (clamp ~lower:0. ~upper:8. 9.) 8.;
+  AT.check (AT.float 0.) "clamp - below range" (clamp ~lower:2. ~upper:8. 1.) 2.;
+  AT.check (AT.float 0.) "clamp - above negative range" (clamp ~lower:(-10.) ~upper:(-5.) 5.) (-5.);
+  AT.check (AT.float 0.) "clamp - below negative range" (clamp ~lower:(-10.) ~upper:(-5.) (-15.)) (-10.);
+  AT.check (AT.bool) "clamp - nan upper bound" (clamp ~lower:(-7.9) ~upper:nan (-6.6) |> isNaN) true;
+  AT.check (AT.bool) "clamp - nan lower bound" (clamp ~lower:nan ~upper:0. (-6.6) |> isNaN) true;
+  AT.check (AT.bool) "clamp - nan value" (clamp ~lower:2. ~upper:8. nan |> isNaN) true;
+  AT.check_raises "clamp - invalid arguments" (Invalid_argument  "~lower:7. must be less than or equal to ~upper:1.") (fun () ->
+    ignore(clamp ~lower:7. ~upper:1. 3.)
+  );
+
+  AT.check (AT.float 0.) "squareRoot - whole numbers" (squareRoot 4.) 2.;
+  AT.check (AT.float 0.) "squareRoot - decimal numbers" (squareRoot 20.25) 4.5;
+  AT.check (AT.bool) "squareRoot - negative number" (squareRoot (-1.) |> isNaN) true;
+
+  AT.check (AT.float 0.) "log - base 10" (log ~base:10. 100.) 2.;
+  AT.check (AT.float 0.) "log - base 2" (log ~base:2. 256.) 8.;
+  AT.check (AT.bool) "log - of zero" (log ~base:10. 0. = negativeInfinity) true;
+
+  AT.check AT.bool "isNaN - nan" (isNaN nan) true;
+  AT.check AT.bool "isNaN - non-nan" (isNaN 91.4) false;
+
+  AT.check AT.bool "isFinite - infinity" (isFinite infinity) false;
+  AT.check AT.bool "isFinite - negative infinity" (isFinite negativeInfinity) false;
+  AT.check AT.bool "isFinite - NaN" (isFinite nan) false;
+  List.iter [-5.; -0.314; 0.; 3.14] ~f:(fun (n) ->
+    AT.check AT.bool ("isFinite - regular numbers - " ^ Base.Float.to_string n) (isFinite n) true;
+  );
+
+  AT.check AT.bool "isInfinite - infinity" (isInfinite infinity) true;
+  AT.check AT.bool "isInfinite - negative infinity" (isInfinite negativeInfinity) true;
+  AT.check AT.bool "isInfinite - NaN" (isInfinite nan) false;
+  List.iter [-5.; -0.314; 0.; 3.14] ~f:(fun (n) ->
+    AT.check AT.bool ("isInfinite - regular numbers - " ^ Base.Float.to_string n) (isInfinite n) false;
+  );
+
+  AT.check AT.bool "inRange - in range" (inRange ~lower:2. ~upper:4. 3.) true;
+  AT.check AT.bool "inRange - above range" (inRange ~lower:2. ~upper:4. 8.) false;
+  AT.check AT.bool "inRange - below range" (inRange ~lower:2. ~upper:4. 1.) false;
+  AT.check AT.bool "inRange - equal to ~upper" (inRange ~lower:1. ~upper:2. 2.) false;
+  AT.check AT.bool "inRange - negative range" (inRange ~lower:(-7.9) ~upper:(-5.2) (-6.6)) true;
+  AT.check AT.bool "inRange - nan upper bound" (inRange ~lower:(-7.9) ~upper:nan (-6.6)) false;
+  AT.check AT.bool "inRange - nan lower bound" (inRange ~lower:nan ~upper:0. (-6.6)) false;
+  AT.check AT.bool "inRange - nan value" (inRange ~lower:2. ~upper:8. nan) false;
+  AT.check_raises "inRange - invalid arguments" (Invalid_argument  "~lower:7. must be less than or equal to ~upper:1.") (fun () ->
+    ignore(inRange ~lower:7. ~upper:1. 3.)
+  );
+
+  AT.check (AT.float 0.) "hypotenuse" (hypotenuse 3. 4.) 5.;
+
+  AT.check (AT.float 0.) "degrees" (degrees 180.) pi;
+
+  AT.check (AT.float 0.) "radians" (radians pi) pi;
+
+  AT.check (AT.float 0.) "turns" (turns 1.) (2. * pi);
+
+  AT.check (AT.pair (AT.float 0.001) (AT.float 0.001)) "fromPolar" (fromPolar (squareRoot 2., degrees 45.)) (1., 1.);
+
+  AT.check (AT.pair (AT.float 0.) (AT.float 0.)) "toPolar" (toPolar (3.0, 4.0)) (5.0, 0.9272952180016122);
+  AT.check (AT.pair (AT.float 0.) (AT.float 1e-5)) "toPolar" (toPolar (5.0, 12.0)) (13.0, 1.1760052070951352);
+
+  AT.check (AT.float 0.) "cos" (cos (degrees 60.)) 0.5000000000000001;
+  AT.check (AT.float 0.) "cos" (cos (radians (pi / 3.))) 0.5000000000000001;
+
+  AT.check (AT.float 0.) "acos" (acos (1. / 2.)) 1.0471975511965979 (* pi / 3. *);
+
+  AT.check (AT.float 0.) "sin - 30 degrees" (sin (degrees 30.)) 0.49999999999999994;
+  AT.check (AT.float 0.) "sin - pi / 6" (sin (radians (pi / 6.))) 0.49999999999999994;
+
+  AT.check (AT.float 0.) "asin" (asin (1. / 2.)) 0.5235987755982989 (* ~ pi / 6. *);
+
+  AT.check (AT.float 0.) "tan - 45 degrees" (tan (degrees 45.)) 0.9999999999999999;
+  AT.check (AT.float 0.) "tan - pi / 4" (tan (radians (pi / 4.))) 0.9999999999999999;
+  AT.check (AT.float 0.) "tan - 0" (tan 0.) 0.;
+
+  AT.check (AT.float 0.) "atan - 0" (atan 0.) 0. ;
+  AT.check (AT.float 0.) "atan - 1 / 1" (atan (1. / 1.)) 0.7853981633974483;
+  AT.check (AT.float 0.) "atan - 1 / -1" (atan (1. / (-1.))) (-0.7853981633974483);
+  AT.check (AT.float 0.) "atan - -1 / -1" (atan ((-1.) / (-1.))) 0.7853981633974483;
+  AT.check (AT.float 0.) "atan - -1 / -1" (atan ((-1.) / 1.)) (-0.7853981633974483);
+
+  AT.check (AT.float 0.) "atan2 0" 0. (atan2 ~y:0. ~x:0.);
+  AT.check (AT.float 0.) "atan2 (1, 1)" 0.7853981633974483 (atan2 ~y:1. ~x:1.);
+  AT.check (AT.float 0.) "atan2 (-1, 1)" 2.3561944901923449 (atan2 ~y:1. ~x:(-1.));
+  AT.check (AT.float 0.) "atan2 (-1, -1)" (-2.3561944901923449) (atan2 ~y:(-1.) ~x:(-1.));
+  AT.check (AT.float 0.) "atan2 (1, -1)" (-0.7853981633974483) (atan2 ~y:(-1.) ~x:1.);
+
+  AT.check (AT.float 0.) "round `Zero" 1. (round ~direction:(`Zero) 1.2);
+  AT.check (AT.float 0.) "round `Zero" 1. (round ~direction:(`Zero) 1.5);
+  AT.check (AT.float 0.) "round `Zero" 1. (round ~direction:(`Zero) 1.8);
+  AT.check (AT.float 0.) "round `Zero" (-1.) (round ~direction:(`Zero) (-1.2));
+  AT.check (AT.float 0.) "round `Zero" (-1.) (round ~direction:(`Zero) (-1.5));
+  AT.check (AT.float 0.) "round `Zero" (-1.) (round ~direction:(`Zero) (-1.8));
+
+  AT.check (AT.float 0.) "round `AwayFromZero" 2. (round ~direction:(`AwayFromZero) 1.2);
+  AT.check (AT.float 0.) "round `AwayFromZero" 2. (round ~direction:(`AwayFromZero) 1.5);
+  AT.check (AT.float 0.) "round `AwayFromZero" 2. (round ~direction:(`AwayFromZero) 1.8);
+  AT.check (AT.float 0.) "round `AwayFromZero" (-2.) (round ~direction:(`AwayFromZero) (-1.2));
+  AT.check (AT.float 0.) "round `AwayFromZero" (-2.) (round ~direction:(`AwayFromZero) (-1.5));
+  AT.check (AT.float 0.) "round `AwayFromZero" (-2.) (round ~direction:(`AwayFromZero) (-1.8));
+
+  AT.check (AT.float 0.) "round `Up" 2. (round ~direction:(`Up) 1.2);
+  AT.check (AT.float 0.) "round `Up" 2. (round ~direction:(`Up) 1.5);
+  AT.check (AT.float 0.) "round `Up" 2. (round ~direction:(`Up) 1.8);
+  AT.check (AT.float 0.) "round `Up" (-1.) (round ~direction:(`Up) (-1.2));
+  AT.check (AT.float 0.) "round `Up" (-1.) (round ~direction:(`Up) (-1.5));
+  AT.check (AT.float 0.) "round `Up" (-1.) (round ~direction:(`Up) (-1.8));
+
+  AT.check (AT.float 0.) "round `Down" 1. (round ~direction:(`Down) 1.2);
+  AT.check (AT.float 0.) "round `Down" 1. (round ~direction:(`Down) 1.5);
+  AT.check (AT.float 0.) "round `Down" 1. (round ~direction:(`Down) 1.8);
+  AT.check (AT.float 0.) "round `Down" (-2.) (round ~direction:(`Down) (-1.2));
+  AT.check (AT.float 0.) "round `Down" (-2.) (round ~direction:(`Down) (-1.5));
+  AT.check (AT.float 0.) "round `Down" (-2.) (round ~direction:(`Down) (-1.8));
+
+  AT.check (AT.float 0.) "round `Closest `Zero" 1. (round ~direction:(`Closest `Zero) 1.2);
+  AT.check (AT.float 0.) "round `Closest `Zero" 1. (round ~direction:(`Closest `Zero) 1.5);
+  AT.check (AT.float 0.) "round `Closest `Zero" 2. (round ~direction:(`Closest `Zero) 1.8);
+  AT.check (AT.float 0.) "round `Closest `Zero" (-1.) (round ~direction:(`Closest `Zero) (-1.2));
+  AT.check (AT.float 0.) "round `Closest `Zero" (-1.) (round ~direction:(`Closest `Zero) (-1.5));
+  AT.check (AT.float 0.) "round `Closest `Zero" (-2.) (round ~direction:(`Closest `Zero) (-1.8));
+
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" 1. (round ~direction:(`Closest `AwayFromZero) 1.2);
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" 2. (round ~direction:(`Closest `AwayFromZero) 1.5);
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" 2. (round ~direction:(`Closest `AwayFromZero) 1.8);
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" (-1.) (round ~direction:(`Closest `AwayFromZero) (-1.2));
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" (-2.) (round ~direction:(`Closest `AwayFromZero) (-1.5));
+  AT.check (AT.float 0.) "round `Closest `AwayFromZero" (-2.) (round ~direction:(`Closest `AwayFromZero) (-1.8));
+
+  AT.check (AT.float 0.) "round `Closest `Up" 1. (round ~direction:(`Closest `Up) 1.2);
+  AT.check (AT.float 0.) "round `Closest `Up" 2. (round ~direction:(`Closest `Up) 1.5);
+  AT.check (AT.float 0.) "round `Closest `Up" 2. (round ~direction:(`Closest `Up) 1.8);
+  AT.check (AT.float 0.) "round `Closest `Up" (-1.) (round ~direction:(`Closest `Up) (-1.2));
+  AT.check (AT.float 0.) "round `Closest `Up" (-1.) (round ~direction:(`Closest `Up) (-1.5));
+  AT.check (AT.float 0.) "round `Closest `Up" (-2.) (round ~direction:(`Closest `Up) (-1.8));
+
+  AT.check (AT.float 0.) "round `Closest `Down" 1. (round ~direction:(`Closest `Down) 1.2);
+  AT.check (AT.float 0.) "round `Closest `Down" 1. (round ~direction:(`Closest`Down) 1.5);
+  AT.check (AT.float 0.) "round `Closest `Down" 2. (round ~direction:(`Closest `Down) 1.8);
+  AT.check (AT.float 0.) "round `Closest `Down" (-1.) (round ~direction:(`Closest `Down) (-1.2));
+  AT.check (AT.float 0.) "round `Closest `Down" (-2.) (round ~direction:(`Closest `Down) (-1.5));
+  AT.check (AT.float 0.) "round `Closest `Down" (-2.) (round ~direction:(`Closest `Down) (-1.8));
+
+  AT.check (AT.float 0.) "round `Closest `ToEven" 1. (round ~direction:(`Closest `ToEven) 1.2);
+  AT.check (AT.float 0.) "round `Closest `ToEven" 2. (round ~direction:(`Closest`ToEven) 1.5);
+  AT.check (AT.float 0.) "round `Closest `ToEven" 2. (round ~direction:(`Closest `ToEven) 1.8);
+  AT.check (AT.float 0.) "round `Closest `ToEven" 2. (round ~direction:(`Closest `ToEven) 2.2);
+  AT.check (AT.float 0.) "round `Closest `ToEven" 2. (round ~direction:(`Closest`ToEven) 2.5);
+  AT.check (AT.float 0.) "round `Closest `ToEven" 3. (round ~direction:(`Closest `ToEven) 2.8);
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-1.) (round ~direction:(`Closest `ToEven) (-1.2));
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-2.) (round ~direction:(`Closest `ToEven) (-1.5));
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-2.) (round ~direction:(`Closest `ToEven) (-1.8));
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-2.) (round ~direction:(`Closest `ToEven) (-2.2));
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-2.) (round ~direction:(`Closest `ToEven) (-2.5));
+  AT.check (AT.float 0.) "round `Closest `ToEven" (-3.) (round ~direction:(`Closest `ToEven) (-2.8));
+
+  AT.check (AT.float 0.) "floor" (floor 1.2) 1.;
+  AT.check (AT.float 0.) "floor" (floor 1.5) 1.;
+  AT.check (AT.float 0.) "floor" (floor 1.8) 1.;
+  AT.check (AT.float 0.) "floor" (floor (-1.2)) (-2.);
+  AT.check (AT.float 0.) "floor" (floor (-1.5)) (-2.);
+  AT.check (AT.float 0.) "floor" (floor (-1.8)) (-2.);
+
+  AT.check (AT.float 0.) "ceiling" (ceiling 1.2) 2.;
+  AT.check (AT.float 0.) "ceiling" (ceiling 1.5) 2.;
+  AT.check (AT.float 0.) "ceiling" (ceiling 1.8) 2.;
+  AT.check (AT.float 0.) "ceiling" (ceiling (-1.2)) (-1.);
+  AT.check (AT.float 0.) "ceiling" (ceiling (-1.5)) (-1.);
+  AT.check (AT.float 0.) "ceiling" (ceiling (-1.8)) (-1.);
+
+  AT.check (AT.float 0.) "truncate" (truncate 1.2) 1.;
+  AT.check (AT.float 0.) "truncate" (truncate 1.5) 1.;
+  AT.check (AT.float 0.) "truncate" (truncate 1.8) 1.;
+  AT.check (AT.float 0.) "truncate" (truncate (-1.2)) (-1.);
+  AT.check (AT.float 0.) "truncate" (truncate (-1.5)) (-1.);
+  AT.check (AT.float 0.) "truncate" (truncate (-1.8)) (-1.);
+
+  AT.check (AT.float 0.) "fromInt - 5" (fromInt 5) 5.0;
+  AT.check (AT.float 0.) "fromInt - 0" (fromInt 0) 0.0;
+  AT.check (AT.float 0.) "fromInt - -7" (fromInt (-7)) (-7.0);
+
+  AT.check (AT.option AT.int) "toInt - 5." (toInt 5.) (Some 5);
+  AT.check (AT.option AT.int) "toInt - 5.3" (toInt 5.3) (Some 5);
+  AT.check (AT.option AT.int) "toInt - 0." (toInt 0.) (Some 0);
+  AT.check (AT.option AT.int) "toInt - -7." (toInt (-7.)) (Some (-7));
+  AT.check (AT.option AT.int) "toInt - nan" (toInt nan) None;
+  AT.check (AT.option AT.int) "toInt - infinity" (toInt infinity) None;
+  AT.check (AT.option AT.int) "toInt - negativeInfinity" (toInt negativeInfinity) None;
+
+  ()
+)
+
+let t_Int () = Int.(
+  AT.check AT.int "zero" zero 0;
+
+  AT.check AT.int "one" one 1;
+
+  AT.check AT.int "minimumValue" (minimumValue - 1) maximumValue;
+
+  AT.check AT.int "maximumValue" (maximumValue + 1) minimumValue;
+
+  AT.check AT.int "add" (add 3002 4004) 7006;
+  AT.check AT.int "+" (3002 + 4004) 7006;
+
+  AT.check AT.int "subtract" (subtract 4 3) 1;
+  AT.check AT.int "-" (4 - 3) 1;
+
+  AT.check AT.int "multiply" (multiply 2 7) 14;
+  AT.check AT.int "*" (2 * 7) 14;
+
+  AT.check AT.int "divide" (divide 3 ~by:2) 1;
+  AT.check_raises "division by zero" Division_by_zero (fun () -> ignore(divide 3 ~by:0));
+
+  AT.check AT.int "/" (27 / 5) 5;
+
+  AT.check (AT.float 0.) "//" (3 // 2) 1.5;
+  AT.check (AT.float 0.) "//" (27 // 5) 5.4;
+  AT.check (AT.float 0.) "//" (8 // 4) 2.0;
+  AT.check (AT.bool) "x // 0" (8 // 0 = Float.infinity) true;
+  AT.check (AT.bool) "-x // 0" (-8 // 0 = Float.negativeInfinity) true;
+
+  AT.check AT.int "power - power" (power ~base:7 ~exponent:3) 343;
+  AT.check AT.int "power - 0 base" (power ~base:0 ~exponent:3) 0;
+  AT.check AT.int "power - 0 exponent" (power ~base:7 ~exponent:0) 1;
+  AT.check AT.int "power - **" (7 ** 3) 343;
+
+  AT.check AT.int "negate - positive number" (negate 8) (-8);
+  AT.check AT.int "negate - negative number" (negate (-7)) 7;
+  AT.check AT.int "negate - zero" (negate 0) (-0);
+  AT.check AT.int "negate - ~-" (~- 7) (-7);
+
+  AT.check AT.int "absolute - positive number" (absolute 8) 8;
+  AT.check AT.int "absolute - negative number" (absolute (-7)) 7;
+  AT.check AT.int "absolute - zero" (absolute 0) 0;
+
+  AT.check AT.int "clamp - in range" (clamp ~lower:0 ~upper:8 5) 5;
+  AT.check AT.int "clamp - above range" (clamp ~lower:0 ~upper:8 9) 8;
+  AT.check AT.int "clamp - below range" (clamp ~lower:2 ~upper:8 1) 2;
+  AT.check AT.int "clamp - above negative range" (clamp ~lower:(-10) ~upper:(-5) 5) (-5);
+  AT.check AT.int "clamp - below negative range" (clamp ~lower:(-10) ~upper:(-5) (-15)) (-10);
+  AT.check_raises "clamp - invalid arguments" (Invalid_argument  "~lower:7 must be less than or equal to ~upper:1") (fun () ->
+    ignore(clamp ~lower:7 ~upper:1 3);
+  );
+
+
+  AT.check AT.bool "inRange - in range" (inRange ~lower:2 ~upper:4 3) true;
+  AT.check AT.bool "inRange - above range" (inRange ~lower:2 ~upper:4 8) false;
+  AT.check AT.bool "inRange - below range" (inRange ~lower:2 ~upper:4 1) false;
+  AT.check AT.bool "inRange - equal to ~upper" (inRange ~lower:1 ~upper:2 2) false;
+  AT.check AT.bool "inRange - negative range" (inRange ~lower:(-7) ~upper:(-5) (-6)) true;
+  AT.check_raises "inRange - invalid arguments" (Invalid_argument "~lower:7 must be less than or equal to ~upper:1") (fun () ->
+    ignore(inRange ~lower:7 ~upper:1 3);
+  );
+
+  AT.check (AT.float 0.) "toFloat - 5" (toFloat 5) 5.;
+  AT.check (AT.float 0.) "toFloat - 0" (toFloat 0) 0.;
+  AT.check (AT.float 0.) "toFloat - -7" (toFloat (-7)) (-7.);
+
+  AT.check AT.(option int) "fromString - 0" (fromString "0") (Some 0);
+  AT.check AT.(option int) "fromString - -0" (fromString "-0") (Some (-0));
+  AT.check AT.(option int) "fromString - 42" (fromString "42") (Some 42);
+  AT.check AT.(option int) "fromString - 123_456" (fromString "123_456") (Some 123_456);
+  AT.check AT.(option int) "fromString - -42" (fromString "-42") (Some (-42));
+  AT.check AT.(option int) "fromString - 0XFF" (fromString "0XFF") (Some 255);
+  AT.check AT.(option int) "fromString - 0X000A" (fromString "0X000A") (Some 10);
+  AT.check AT.(option int) "fromString - Infinity" (fromString "Infinity") None;
+  AT.check AT.(option int) "fromString - -Infinity" (fromString "-Infinity") None;
+  AT.check AT.(option int) "fromString - NaN" (fromString "NaN") None;
+  AT.check AT.(option int) "fromString - abc" (fromString "abc") None;
+  AT.check AT.(option int) "fromString - --4" (fromString "--4") None;
+  AT.check AT.(option int) "fromString - empty string" (fromString " ") None;
+
+  AT.check AT.string " toString - positive number" (toString 1) "1";
+  AT.check AT.string " toString - negative number" (toString (-1)) "-1";
+
+  ()
+)
 
 let t_List () =
   AT.check (AT.list AT.int) "reverse empty list" (List.reverse []) [];
@@ -293,16 +624,16 @@ let t_List () =
 
   AT.check (AT.option AT.int) "minimumBy non-empty list" (List.minimumBy ~f:(fun x -> x mod 12) [7;9;15;10;3;22]) (Some 15);
   AT.check (AT.option AT.int) "minimumBy empty list" (List.minimumBy ~f:(fun x -> x mod 12) []) None;
-  
+
   AT.check (AT.option AT.int) "maximumBy non-empty list" (List.maximumBy ~f:(fun x -> x mod 12) [7;9;15;10;3;22]) (Some 10);
   AT.check (AT.option AT.int) "maximumBy empty list" (List.maximumBy ~f:(fun x -> x mod 12) []) None;
-  
+
   AT.check (AT.option AT.int) "minimum non-empty list" (List.minimum [7;9;15;10;3]) (Some 3);
   AT.check (AT.option AT.int) "minimum empty list" (List.minimum []) None;
-  
+
   AT.check (AT.option AT.int) "maximum non-empty list" (List.maximum [7;9;15;10;3]) (Some 15);
   AT.check (AT.option AT.int) "maximum empty list" (List.maximum []) None;
-  
+
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition empty list" (List.partition ~f:(fun x -> x mod 2 = 0) []) ([], []);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition one element" (List.partition ~f:(fun x -> x mod 2 = 0) [1]) ([], [1]);
   AT.check (AT.pair (AT.list AT.int) (AT.list AT.int)) "partition four elements" (List.partition ~f:(fun x -> x mod 2 = 0) [1;2;3;4]) ([2;4], [1;3]);
@@ -354,20 +685,18 @@ let t_Tuple2 () =
 
   ()
 
-
-
 let t_Tuple3 () =
   AT.check (trio AT.int AT.int AT.int) "create" (Tuple3.create 3 4 5) (3, 4, 5);
 
   AT.check AT.int "first" (Tuple3.first (3, 4, 5)) 3;
 
-  AT.check AT.int "second" (Tuple3.second (3, 4, 5)) 4;      
+  AT.check AT.int "second" (Tuple3.second (3, 4, 5)) 4;
 
-  AT.check AT.int "third" (Tuple3.third (3, 4, 5)) 5;      
+  AT.check AT.int "third" (Tuple3.third (3, 4, 5)) 5;
 
-  AT.check (AT.pair AT.int AT.int) "init" (Tuple3.init (3, 4, 5)) (3, 4);      
+  AT.check (AT.pair AT.int AT.int) "init" (Tuple3.init (3, 4, 5)) (3, 4);
 
-  AT.check (AT.pair AT.int AT.int) "tail" (Tuple3.tail (3, 4, 5)) (4, 5);      
+  AT.check (AT.pair AT.int AT.int) "tail" (Tuple3.tail (3, 4, 5)) (4, 5);
 
   AT.check (trio AT.string AT.int AT.bool) "mapFirst" (Tuple3.mapFirst ~f:String.reverse ("stressed", 16, false)) ("desserts", 16, false);
 
@@ -378,9 +707,9 @@ let t_Tuple3 () =
   AT.check (trio AT.string (AT.float 0.) AT.bool) "mapEach" (Tuple3.mapEach ~f:String.reverse ~g:sqrt ~h:not ("stressed", 16., false)) ("desserts", 4., true);
 
   AT.check (trio AT.string AT.string AT.string) "mapAll" (Tuple3.mapAll ~f:String.reverse ("was", "stressed", "now")) ("saw", "desserts", "won");
-  
+
   AT.check (trio AT.int AT.int AT.int) "rotateLeft" (Tuple3.rotateLeft (3, 4, 5)) (4, 5, 3);
-  
+
   AT.check (trio AT.int AT.int AT.int) "rotateRight" (Tuple3.rotateRight (3, 4, 5)) (5, 3, 4);
 
   AT.check AT.int "curry" (Tuple3.curry (fun (a, b, c) -> a + b + c) 3 4 5) 12;
@@ -392,9 +721,12 @@ let t_Tuple3 () =
   ()
 
 let suite = [
-  ("Array", `Quick, t_Array); 
-  ("Char", `Quick, t_Char); 
-  ("String", `Quick, t_String); 
+  ("Array", `Quick, t_Array);
+  ("Char", `Quick, t_Char);
+  ("Float", `Quick, t_Float);
+  ("Int", `Quick, t_Int);
+  ("List", `Quick, t_List);
+  ("String", `Quick, t_String);
   ("Tuple2", `Quick, t_Tuple2);
   ("Tuple3", `Quick, t_Tuple3);
 ]


### PR DESCRIPTION
This expands the Int and Float modules to cover the operations detailed in https://package.elm-lang.org/packages/elm/core/latest/Basics#Int

Some notable differences include:
- All operators also get a named function equivalent
- The `clamp`, `hypotenuse` and `inRange` functions are introduced 
- `round`, `floor`, `ceiling` and `truncate` return a `float` instead of an int with `Float.toInt` serving as the only way to convert to an integer.
- `round` has been expanded to cover (most of) the many possible ways to go about rounding floating point numbers. The documentation for this one might be a little over the top, I wasn't sure about the clearest way to demonstrate the behaviour.
- `logBase` becomes `log ~base:`
- `min`, `max`, `mod`, `sqrt` and `abs` get non-abbreviated names
- `remainderBy` and `modBy` drop the 'By' and get a labelled argument
- `clamp` and `inRange` can throw an exception if the `upper` argument is less than the `lower` argument.

I intend to squash the commits.