### PR TITLE
Fix type signatures for flatMap

### DIFF
--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -126,9 +126,9 @@ module Array : sig
 
   val map3 : f:('a -> 'b -> 'c -> 'd) -> 'a array -> 'b array -> 'c array -> 'd array
 
-  val flatMap : f:('a -> 'a array) -> 'a array -> 'a array
+  val flatMap : f:('a -> 'b array) -> 'a array -> 'b array
 
-  val flat_map : f:('a -> 'a array) -> 'a array -> 'a array
+  val flat_map : f:('a -> 'b array) -> 'a array -> 'b array
 
   val find : f:('a -> bool) -> 'a array -> 'a option
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -190,14 +190,14 @@ Array.map2
       [|("alice", 2, true); ("bob", 5, false); ("chuck", 7, true)|]
     ]} *)
 
-  val flatMap : f:('a -> 'a array) -> 'a array -> 'a array
+  val flatMap : f:('a -> 'b array) -> 'a array -> 'b array
   (** Apply a function [f] onto an array and flatten the resulting array of arrays.
 
     {[Array.flatMap ~f xs = Array.map ~f xs |> Array.flatten]} 
     
     {[Array.flatMap ~f:(fun n -> [|n; n|]) [|1; 2; 3|] = [|1; 1; 2; 2; 3; 3|]]} *)
 
-  val flat_map : f:('a -> 'a array) -> 'a array -> 'a array
+  val flat_map : f:('a -> 'b array) -> 'a array -> 'b array
 
   val find : f:('a -> bool) -> 'a array -> 'a option
   (** Returns as an option the first element for which f evaluates to true. If [f] doesn't return [true] for any of the elements [find] will return [None] 


### PR DESCRIPTION
The interface file doesn't match the types in the implementation file. Small change that fixes the interface file to accurately reflect the type signature of flatMap.