### PR TITLE
Fix native test of Float module on macOS

### DIFF
--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -386,17 +386,17 @@ let t_Float () = Float.(
   AT.check (AT.pair (AT.float 0.001) (AT.float 0.001)) "fromPolar" (fromPolar (squareRoot 2., degrees 45.)) (1., 1.);
 
   AT.check (AT.pair (AT.float 0.) (AT.float 0.)) "toPolar" (toPolar (3.0, 4.0)) (5.0, 0.9272952180016122);
-  AT.check (AT.pair (AT.float 0.) (AT.float 1e-5)) "toPolar" (toPolar (5.0, 12.0)) (13.0, 1.1760052070951352);
+  AT.check (AT.pair (AT.float 0.) (AT.float 1e-15)) "toPolar" (toPolar (5.0, 12.0)) (13.0, 1.1760052070951352);
 
   AT.check (AT.float 0.) "cos" (cos (degrees 60.)) 0.5000000000000001;
   AT.check (AT.float 0.) "cos" (cos (radians (pi / 3.))) 0.5000000000000001;
 
-  AT.check (AT.float 0.) "acos" (acos (1. / 2.)) 1.0471975511965979 (* pi / 3. *);
+  AT.check (AT.float 1e-15) "acos" (acos (1. / 2.)) 1.0471975511965979 (* pi / 3. *);
 
   AT.check (AT.float 0.) "sin - 30 degrees" (sin (degrees 30.)) 0.49999999999999994;
   AT.check (AT.float 0.) "sin - pi / 6" (sin (radians (pi / 6.))) 0.49999999999999994;
 
-  AT.check (AT.float 0.) "asin" (asin (1. / 2.)) 0.5235987755982989 (* ~ pi / 6. *);
+  AT.check (AT.float 1e-15) "asin" (asin (1. / 2.)) 0.5235987755982989 (* ~ pi / 6. *);
 
   AT.check (AT.float 0.) "tan - 45 degrees" (tan (degrees 45.)) 0.9999999999999999;
   AT.check (AT.float 0.) "tan - pi / 4" (tan (radians (pi / 4.))) 0.9999999999999999;


### PR DESCRIPTION
I got errors of native test related Float module on macOS. Because **double** in IEEE 754-1985 can represent 15 to 17 significant decimal digits, I change it to 15 digits for `acos`, `asin`, and `toPolar`. BTW I don't know why `toPolar` was specified `1e-5` originally.

Tested environment:
- macOS 10.14.5
- OCaml 4.07.1

Here is a partial output of terminal on macOS (full output is [here](https://gist.github.com/kuy/227d7422a54fd43464dde9b00c81bbb3)).
```
--------------------------------------------------------------------------------
ASSERT cos
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
ASSERT acos
--------------------------------------------------------------------------------
[failure] Error acos: expecting
1.0472, got
1.0472.
Raised at file "stdlib.ml", line 33, characters 17-33
Called from file "native/test/test.ml", line 394, characters 2-67
Called from file "alcotest/junit_alcotest.ml", line 10, characters 6-13
Re-raised at file "alcotest/junit_alcotest.ml", line 26, characters 6-15
Called from file "src/alcotest.ml", line 285, characters 8-14
```

`1.04719755119659763` OCaml 4.07.1 macOS
`1.04719755119659785` OCaml 4.07.1 [ocaml/opam2](https://hub.docker.com/r/ocaml/opam2) (same as CI env)