### PR TITLE
WIP: Add Float.toString/to_string

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -710,6 +710,21 @@ let () =
       test "infinity" (fun () -> expect (toInt infinity) |> toEqual None);
       test "negativeInfinity" (fun () -> expect (toInt negativeInfinity) |> toEqual None);
     );
+
+    describe "toString" (fun () ->
+      test "3." (fun () -> expect (toString 3.) |> toEqual "3");
+      test "-3." (fun () -> expect (toString (-3.)) |> toEqual "-3");
+      test "0." (fun () -> expect (toString 0.) |> toEqual "0");
+      test "-0." (fun () -> expect (toString (-0.)) |> toEqual "0");
+      test "1.23456789012345" (fun () -> expect (toString 1.23456789012345) |> toEqual "1.23456789012345");
+      test "1.234567890123456" (fun () -> expect (toString 1.234567890123456) |> toEqual "1.234567890123456");
+      test "1.2345678901234567" (fun () -> expect (toString 1.2345678901234567) |> toEqual "1.2345678901234567");
+      test "9.12345678912345" (fun () -> expect (toString 9.12345678912345) |> toEqual "9.12345678912345");
+      test "9.123456789123456" (fun () -> expect (toString 9.123456789123456) |> toEqual "9.123456789123456");
+      test "nan" (fun () -> expect (toString nan) |> toEqual "NaN");
+      test "infinity" (fun () -> expect (toString infinity) |> toEqual "Infinity");
+      test "negativeInfinity" (fun () -> expect (toString negativeInfinity) |> toEqual "-Infinity");
+    );
   ));
 
   describe "Int" (fun () -> Int.(

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -821,6 +821,10 @@ module Float = struct
       None
 
   let to_int = toInt
+
+  let toString = Js.Float.toString
+
+  let to_string = toString
 end
 
 module Int = struct

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -3011,6 +3011,10 @@ Float.round ~direction:`Up (-1.8) = -1.0
   *)
 
   val to_int : t ->  int option
+
+  val toString : t -> string
+
+  val to_string : t -> string
 end
 
 module Int : sig

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -836,6 +836,10 @@ module Float = struct
   let toInt = Base.Float.iround_towards_zero
 
   let to_int = toInt
+
+  let toString = Base.Float.to_string
+
+  let to_string = toString
 end
 
 module Int = struct

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -1349,6 +1349,10 @@ Float.round ~direction:`Up (-1.8) = -1.0
   *)
 
   val to_int : t ->  int option
+
+  val toString : t -> string
+
+  val to_string : t -> string
 end
 
 module Int : sig

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -516,6 +516,19 @@ let t_Float () = Float.(
   AT.check (AT.option AT.int) "toInt - infinity" (toInt infinity) None;
   AT.check (AT.option AT.int) "toInt - negativeInfinity" (toInt negativeInfinity) None;
 
+  AT.check AT.string "toString - 3." (toString 3.) "3.";
+  AT.check AT.string "toString - -3." (toString (-3.)) "-3.";
+  AT.check AT.string "toString - 0." (toString 0.) "0.";
+  AT.check AT.string "toString - -0." (toString (-0.)) "-0.";
+  AT.check AT.string "toString - 1.23456789012345" (toString 1.23456789012345) "1.23456789012345";
+  AT.check AT.string "toString - 1.234567890123456" (toString 1.234567890123456) "1.234567890123456";
+  AT.check AT.string "toString - 1.2345678901234567" (toString 1.2345678901234567) "1.2345678901234567";
+  AT.check AT.string "toString - 9.01234567890123" (toString 9.01234567890123) "9.01234567890123";
+  AT.check AT.string "toString - 9.012345678901234" (toString 9.012345678901234) "9.012345678901234";
+  AT.check AT.string "toString - nan" (toString nan) "nan";
+  AT.check AT.string "toString - infinity" (toString infinity) "inf";
+  AT.check AT.string "toString - negativeInfinity" (toString negativeInfinity) "-inf";
+
   ()
 )
 


### PR DESCRIPTION
*(PR code is Work In Progress)*

I wanted to make an implementation that has the exact same behaviour for both platforms, but I finally found it's difficult without author's dicision. For example, a string representation of **Infinity**: In JavaScfipt, `Infinity` is used and `inf` in OCaml. In addition to this, OCaml returns `3.` (with dot) but JavaScript returns just `3`.  [Full output](https://gist.github.com/kuy/0318f923ca36cc42a0992658ef08d95c) at Gist.

- Option 1: Allow different output for each platform
- Option 2: Define an output of Tablecloth (neither JS nor OCaml)
- Option 3: Standardize to JS or OCaml

In [Design of Tablecloth](https://github.com/darklang/tablecloth#tablecloths-solution) section, you say that Tablecloth should has identical API, but it doesn't say Tablecloth should return the exact same output. OCaml users may suprise if `Float.to_string` returns `Infinity` and ReasonML/BackleScript users may suprise if `Float.toString` returns `inf`.

My conclusion: Option 1

Pros: No suprise for both platforms.
Cons: Need to write some code to get the exact same output.

I think Tablecloth need to keep a neutral position. To keep it, **Option 3** is a possible option.

Please let me hear what you think :)