### PR TITLE
Add `Option.getExn`

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -1070,3 +1070,13 @@ let () =
       expect (Tuple3.toList (3, 4, 5)) |> toEqual [3; 4; 5]
     );
   );
+
+  describe "Option" (fun () ->
+    test "getExn Some(1)" (fun () ->
+      expect (Option.getExn(Some(1))) |> toEqual 1
+    );
+
+    test "getExn None" (fun () ->
+      expect (fun () -> Option.getExn(None)) |> toThrowException (Invalid_argument "option is None")
+    );
+  );

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -512,6 +512,13 @@ module Option = struct
     if value = sentinel then None else Some value
 
   let to_option = toOption
+
+  let getExn = fun (x: 'a option) ->
+    match x with
+    | None -> raise (Invalid_argument "option is None")
+    | Some(x) -> x
+
+  let get_exn = getExn
 end
 
 module Char = struct  

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -1237,6 +1237,21 @@ module Option : sig
     [Option.to_option ~sentinel:s, x] returns [Some x] unless [x] equals the sentinel
     value [s], in which case [Option.to_option] returns [None].
   *)
+
+  val getExn : 'a option -> 'a
+  (**
+    Same as {!Option.get_exn}
+  *)
+
+  val get_exn : 'a option -> 'a
+  (** [get_exn optional_value]
+    Returns [value] if [optional_value] is [Some value], otherwise raises [get_exn]
+
+    @example {[
+      get_exn (Some 3) = 3;;
+      get_exn None (* Raises get_exn error *)
+    ]}
+  *)
 end
 
 (**

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -536,6 +536,13 @@ module Option = struct
     if value = sentinel then None else Some value
 
   let to_option = toOption
+
+  let getExn = fun (x: 'a option) ->
+    match x with
+    | None -> raise (Invalid_argument "option is None")
+    | Some(x) -> x
+
+  let get_exn = getExn
 end
 
 module Result = struct

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -524,6 +524,21 @@ module Option : sig
   val toOption : sentinel:'a -> 'a -> 'a option
 
   val to_option : sentinel:'a -> 'a -> 'a option
+
+  val getExn : 'a option -> 'a
+  (**
+    Same as {!Option.get_exn}
+  *)
+
+  val get_exn : 'a option -> 'a
+  (** [get_exn optional_value]
+    Returns [value] if [optional_value] is [Some value], otherwise raises [Invalid_argument]
+
+    @example {[
+      get_exn (Some 3) = 3;;
+      get_exn None (* Raises Invalid_argument error *)
+    ]}
+  *)
 end
 
 module Char : sig

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -774,6 +774,13 @@ let t_Tuple3 () =
 
   ()
 
+let t_Option () =
+  AT.check AT.int "getExn Some(1)" (Option.getExn (Some(1))) 1;
+
+  AT.check_raises "getExn None" (Invalid_argument "option is None") (fun () -> (Option.getExn (None)));
+
+  ()
+
 let suite = [
   ("Array", `Quick, t_Array);
   ("Char", `Quick, t_Char);
@@ -783,6 +790,7 @@ let suite = [
   ("String", `Quick, t_String);
   ("Tuple2", `Quick, t_Tuple2);
   ("Tuple3", `Quick, t_Tuple3);
+  ("Option", `Quick, t_Option);
 ]
 
 let () =


### PR DESCRIPTION
If this was left out of the API for philosophical reasons, feel free to
close the PR, but I think it makes sense. Bikeshedding the name welcome.

See also [this discussion][1] on StackOverflow about the corresponding
API in Elm.

[1]: https://stackoverflow.com/questions/28699800/right-way-to-forcibly-convert-maybe-a-to-a-in-elm-failing-clearly-for-nothings

Test plan:

`./build.sh` passes