### PR TITLE
Consume Makefile in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,20 @@ jobs:
       CI: true
       NODE_ENV: test
 
-    working_directory: ~/repo/bs
+    working_directory: ~/repo
     steps:
       - checkout:
           path: ~/repo
       - restore_cache:
           keys:
-            - v1-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - v1-dependencies-{{ .Branch }}-{{ checksum "bs/package-lock.json" }}
             - v1-dependencies-{{ .Branch }}-
             - v1-dependencies-
-      - run: npm install
-      - run: npm run build
-      - run: npm test
+      - run: make deps-bs
+      - run: make build-bs
+      - run: make test-bs
       - save_cache:
-          key: v1-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: v1-dependencies-{{ .Branch }}-{{ checksum "bs/package-lock.json" }}
           paths:
             - ~/repo/bs/node_modules
 
@@ -30,7 +30,7 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
-    working_directory: ~/repo/native
+    working_directory: ~/repo
     steps:
       - checkout:
           path: ~/repo
@@ -41,9 +41,9 @@ jobs:
             - v2-native-dependencies-
       # m4 is a system dependency required by conf-m4 -> ocamlfind -> fmt -> alcotest
       - run: sudo apt-get install -y m4
-      - run: opam update && opam install alcotest base dune junit junit_alcotest -y
-      - run: opam config exec -- dune build
-      - run: opam config exec -- dune runtest -f
+      - run: make deps-native
+      - run: make build-native
+      - run: make test-native
       - save_cache:
           key: v2-native-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build-native:
 	echo -e "\n\e[31mBuilding tablecloth-native ...\e[0m"
-	cd native && dune build
+	cd native && opam config exec -- dune build
 	echo -e "\n\e[31mBuilt!\e[0m"
 
 build-bs:
@@ -14,7 +14,7 @@ build:
 
 test-native:
 	echo -e "\n\e[31mRunning tablecloth-native tests ...\e[0m"
-	cd native && dune runtest -f
+	cd native && opam config exec -- dune runtest -f
 	echo -e "\n\e[31mTested!\e[0m"
 
 test-bs:
@@ -23,11 +23,23 @@ test-bs:
 	echo -e "\n\e[31mTested!\e[0m"
 
 test:
-	@$(MAKE) test-native 
+	@$(MAKE) test-native
 	@$(MAKE) test-bs
 
-docs:
-	echo -e "\n\e[31mCompiling the documentation ...\e[0m"
-	dune build @doc
-	echo -e "\n\e[31mCompiled! The docs are now viewable at _build/default/_doc/_html/index.html\e[0m"
+deps-native:
+	echo -e "\n\e[31mInstalling native dependencies ...\e[0m"
+	opam update
+	opam install alcotest base dune junit junit_alcotest -y
+	echo -e "\n\e[31mInstalled!\e[0m"
 
+deps-bs:
+	echo -e "\n\e[31mInstalling bs dependencies ...\e[0m"
+	cd bs && npm install
+	echo -e "\n\e[31mInstalled!\e[0m"
+
+documentation:
+	echo -e "\n\e[31mCompiling the documentation ...\e[0m"
+	opam exec -- dune build @doc
+	rm ./docs
+	ln -s _build/default/_doc/_html ./docs
+	echo -e "\n\e[31mCompiled! The docs are now viewable at ./docs/index.html\e[0m"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ a handful of useful, supported commands:
 
 - `make build`: Build the project.
 - `make test`: Run the test suite. You may need to `make build` first.
-- `make docs`: Build the documentation to browse offline.
+- `make documentation`: Build the documentation to browse offline.
 
 ## License
 


### PR DESCRIPTION
- Couple the CircleCI configuration to some of the Makefile commands
- Support new `opam-deps` command in the Makefile
- Change `make docs` -> `make documentation`