### PR TITLE
Clean up makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,45 @@
 build-native:
-	echo -e "\n\e[31mBuilding tablecloth-native ...\e[0m"
+	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
 	cd native && opam config exec -- dune build
-	echo -e "\n\e[31mBuilt!\e[0m"
+	@printf "\n\e[31mBuilt!\e[0m\n"
 
 build-bs:
-	echo -e "\n\e[31mBuilding bs ...\e[0m"
+	@printf "\n\e[31mBuilding bs ...\e[0m\n"
 	cd bs && npm run build
-	echo -e "\n\e[31mBuilt!\e[0m"
+	@printf "\n\e[31mBuilt!\e[0m\n"
 
 build:
 	@$(MAKE) build-native
 	@$(MAKE) build-bs
 
 test-native:
-	echo -e "\n\e[31mRunning tablecloth-native tests ...\e[0m"
+	@printf "\n\e[31mRunning tablecloth-native tests ...\e[0m\n"
 	cd native && opam config exec -- dune runtest -f
-	echo -e "\n\e[31mTested!\e[0m"
+	@printf "\n\e[31mTested!\e[0m\n"
 
 test-bs:
-	echo -e "\n\e[31mRunning tablecloth-bs tests ...\e[0m"
+	@printf "\n\e[31mRunning tablecloth-bs tests ...\e[0m\n"
 	cd bs && npm run test
-	echo -e "\n\e[31mTested!\e[0m"
+	@printf "\n\e[31mTested!\e[0m\n"
 
 test:
 	@$(MAKE) test-native
 	@$(MAKE) test-bs
 
 deps-native:
-	echo -e "\n\e[31mInstalling native dependencies ...\e[0m"
+	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
 	opam install alcotest base dune junit junit_alcotest -y
-	echo -e "\n\e[31mInstalled!\e[0m"
+	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-bs:
-	echo -e "\n\e[31mInstalling bs dependencies ...\e[0m"
+	@printf "\n\e[31mInstalling bs dependencies ...\e[0m\n"
 	cd bs && npm install
-	echo -e "\n\e[31mInstalled!\e[0m"
+	@printf "\n\e[31mInstalled!\e[0m\n"
 
 documentation:
-	echo -e "\n\e[31mCompiling the documentation ...\e[0m"
+	@printf "\n\e[31mCompiling the documentation ...\e[0m\n"
 	opam exec -- dune build @doc
 	rm ./docs
 	ln -s _build/default/_doc/_html ./docs
-	echo -e "\n\e[31mCompiled! The docs are now viewable at ./docs/index.html\e[0m"
+	@printf "\n\e[31mCompiled! The docs are now viewable at ./docs/index.html\e[0m\n"


### PR DESCRIPTION
`echo -e` doesn't exist on macOS so the output of `make build` is
unreadable. I swapped it out for `printf` which works as expected. I
read that `printf` works on Linux too so hopefully nothing regressed.

Before:

```bash
$ make build
echo -e "\n\e[31mBuilding tablecloth-native ...\e[0m"
-e
\e[31mBuilding tablecloth-native ...\e[0m
cd native && opam config exec -- dune build
Entering directory '/Users/dmnd/github/tablecloth'
echo -e "\n\e[31mBuilt!\e[0m"
-e
\e[31mBuilt!\e[0m
echo -e "\n\e[31mBuilding bs ...\e[0m"
-e
\e[31mBuilding bs ...\e[0m
cd bs && npm run build

> tablecloth-bucklescript@0.0.6 build /Users/dmnd/github/tablecloth/bs
> bsb -make-world

[5/5] Building src/jest.cmj
[8/8] Building __tests__/tablecloth_test.cmj
echo -e "\n\e[31mBuilt!\e[0m"
-e
\e[31mBuilt!\e[0m
```

After:

```bash
$ make build

Building tablecloth-native ...
cd native && opam config exec -- dune build
Entering directory '/Users/dmnd/github/tablecloth'

Built!

Building bs ...
cd bs && npm run build

> tablecloth-bucklescript@0.0.6 build /Users/dmnd/github/tablecloth/bs
> bsb -make-world

[5/5] Building src/jest.cmj
[8/8] Building __tests__/tablecloth_test.cmj

Built!
```

The above displays with the correct colours on macOS too.