### PR TITLE
New `Array.get` and `Array.set` APIs

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -104,26 +104,42 @@ let () =
               |> toEqual [ (0, "cat"); (1, "dog") ])) ;
 
       describe "get" (fun () ->
-          test "returns Some for an in-bounds indexe" (fun () ->
-              expect (Array.get ~index:2 [| "cat"; "dog"; "eel" |])
+          test "returns Some for an in-bounds index" (fun () ->
+              expect [| "cat"; "dog"; "eel" |].(2) |> toEqual (Some "eel")) ;
+
+          test "returns None for an out of bounds index" (fun () ->
+              expect [| 0; 1; 2 |].(5) |> toEqual None) ;
+
+          test "returns None for an empty array" (fun () ->
+              expect [||].(0) |> toEqual None)) ;
+
+      describe "getAt" (fun () ->
+          test "returns Some for an in-bounds index" (fun () ->
+              expect (Array.getAt ~index:2 [| "cat"; "dog"; "eel" |])
               |> toEqual (Some "eel")) ;
 
           test "returns None for an out of bounds index" (fun () ->
-              expect (Array.get ~index:5 [| 0; 1; 2 |]) |> toEqual None) ;
+              expect (Array.getAt ~index:5 [| 0; 1; 2 |]) |> toEqual None) ;
 
           test "returns None for an empty array" (fun () ->
-              expect (Array.get ~index:0 [||]) |> toEqual None)) ;
+              expect (Array.getAt ~index:0 [||]) |> toEqual None)) ;
 
       describe "set" (fun () ->
+          test "can set a value at an index" (fun () ->
+              let numbers = [| 1; 2; 3 |] in
+              numbers.(0) <- 0 ;
+              expect numbers |> toEqual [| 0; 2; 3 |])) ;
+
+      describe "setAt" (fun () ->
           test "can be partially applied to set an element" (fun () ->
-              let setZero = Array.set ~value:0 in
+              let setZero = Array.setAt ~value:0 in
               let numbers = [| 1; 2; 3 |] in
               setZero numbers ~index:2 ;
               setZero numbers ~index:1 ;
               expect numbers |> toEqual [| 1; 0; 0 |]) ;
 
           test "can be partially applied to set an index" (fun () ->
-              let setZerothElement = Array.set ~index:0 in
+              let setZerothElement = Array.setAt ~index:0 in
               let animals = [| "ant"; "bat"; "cat" |] in
               setZerothElement animals ~value:"antelope" ;
               expect animals |> toEqual [| "antelope"; "bat"; "cat" |])) ;
@@ -404,7 +420,7 @@ let () =
           let index = ref 0 in
           let calledValues = [| 0; 0; 0 |] in
           Array.forEach [| 1; 2; 3 |] ~f:(fun value ->
-              Array.set calledValues ~index:!index ~value ;
+              Array.setAt calledValues ~index:!index ~value ;
               index := !index + 1) ;
 
           expect calledValues |> toEqual [| 1; 2; 3 |])) ;

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -47,9 +47,17 @@ module Array = struct
 
   let to_indexed_list = toIndexedList
 
-  let get ~index array = Belt.Array.get array index
+  let get = Belt.Array.get
 
-  let set ~index ~value array = array.(index) <- value
+  let getAt ~index array = get array index
+
+  let get_at = getAt
+
+  let set array index value = array.(index) <- value
+
+  let setAt ~index ~value array = set array index value
+
+  let set_at = setAt
 
   let sum (a : int array) : int = Belt.Array.reduce a 0 ( + )
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -82,9 +82,17 @@ module Array : sig
 
   val to_indexed_list : 'a array -> (int * 'a) list
 
-  val get : index:int -> 'a array -> 'a option
+  val get : 'a array -> int -> 'a option
 
-  val set : index:int -> value:'a -> 'a array -> unit
+  val getAt : index:int -> 'a array -> 'a option
+
+  val get_at : index:int -> 'a array -> 'a option
+
+  val set : 'a array -> int -> 'a -> unit
+
+  val setAt : index:int -> value:'a -> 'a array -> unit
+
+  val set_at : index:int -> value:'a -> 'a array -> unit
 
   val sum : int array -> int
 

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -51,13 +51,21 @@ module Array = struct
 
   let to_indexed_list = toIndexedList
 
-  let get ~index a =
+  let get a index =
     if index >= 0 && index < length a
     then Some (Base.Array.get a index)
     else None
 
 
-  let set ~index ~value a = Base.Array.set a index value
+  let getAt ~index a = get a index
+
+  let get_at = getAt
+
+  let set = Base.Array.set
+
+  let setAt ~index ~value a = set a index value
+
+  let set_at = setAt
 
   let sum (a : int array) : int = Base.Array.fold a ~init:0 ~f:( + )
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -94,8 +94,8 @@ module Array : sig
 
   val to_indexed_list : 'a array -> (int * 'a) list
 
-  val get : index:int -> 'a array -> 'a option
-  (** [Array.get ~index:n a] returns, as an {!Option}, the element at index number [n] of array [a].
+  val get : 'a array -> int -> 'a option
+  (** [Array.get a n] returns, as an {!Option}, the element at index number [n] of array [a].
 
     The first element has index number 0.
 
@@ -103,35 +103,28 @@ module Array : sig
 
     Returns [None] if [n] is outside the range [0] to [(Array.length a - 1)].
 
-    You can also write [a.(n)] instead of [Array.get a n] but this raises [Invalid_argument "index out of bounds"] for index outside of the range of the array.
+    You can also write [a.(n)] instead of [Array.get n a]
 
-    {[Array.get ~index:2 [|"cat"; "dog"; "eel"|] = Some "eel"]}
+    {[Array.get [|"cat"; "dog"; "eel"|] 2 = Some "eel"]}
 
-    {[Array.get ~index:5 [|0; 1; 2|] = None]}
+    {[Array.get [|0; 1; 2|] 5 = None]}
 
-    {[Array.get ~index:0 [||] = None]} *)
+    {[Array.get [||] 0 = None]} *)
 
-  val set : index:int -> value:'a -> 'a array -> unit
-  (** [Array.set a ~index:n ~value:x] modifies array [a] in place, replacing the element at index number [n] with [x].
+  val getAt : index:int -> 'a array -> 'a option
 
-    You can also write [a.(n) <- x] instead of [Array.set a ~index:n ~value:x].
+  val get_at : index:int -> 'a array -> 'a option
 
-    Raises [Invalid_argument "index out of bounds"] if [n] is outside the range [0] to [Array.length a - 1]. 
-    
-    {[let setZero = Array.set ~value:0 in
-let numbers = [|1;2;3|] in
-  
-setZero numbers ~index:2;
-setZero numbers ~index:1;
+  val set : 'a array -> int -> 'a -> unit
+  (** [Array.set a i x] modifies array [a] in place, replacing the element at index number [i] with [x].
 
-numbers = [|1;0;0|]]}
+    You can also write [a.(n) <- x] instead of [Array.set a i x].
 
-    {[let setZerothElement = Array.set ~index:0 in
-let animals = [|"ant"; "bat"; "cat"|] in
+    Raises [Invalid_argument "index out of bounds"] if [i] is outside the range [0] to [Array.length a - 1]. *)
 
-setZerothElement animals ~value:"antelope";
+  val setAt : index:int -> value:'a -> 'a array -> unit
 
-animals = [|"antelope"; "bat"; "cat"|]]} *)
+  val set_at : index:int -> value:'a -> 'a array -> unit
 
   val sum : int array -> int
   (** Get the total of adding all of the integers in an array. 

--- a/native/test/test.ml
+++ b/native/test/test.ml
@@ -222,24 +222,48 @@ let t_Array () =
 
   AT.check
     (AT.option AT.string)
-    "get - returns Some for an in-bounds indexe"
-    (Array.get ~index:2 [| "cat"; "dog"; "eel" |])
+    "get - returns Some for an in-bounds index"
+    [| "cat"; "dog"; "eel" |].(2)
     (Some "eel") ;
   AT.check
     (AT.option AT.int)
     "get - returns None for an out of bounds index"
-    (Array.get ~index:5 [| 0; 1; 2 |])
+    [| 0; 1; 2 |].(5)
     None ;
   AT.check
     (AT.option AT.int)
     "get - returns None for an empty array"
-    (Array.get ~index:0 [||])
+    [||].(0)
+    None ;
+
+  AT.check
+    (AT.option AT.string)
+    "getAt - returns Some for an in-bounds index"
+    (Array.getAt ~index:2 [| "cat"; "dog"; "eel" |])
+    (Some "eel") ;
+  AT.check
+    (AT.option AT.int)
+    "getAt - returns None for an out of bounds index"
+    (Array.getAt ~index:5 [| 0; 1; 2 |])
+    None ;
+  AT.check
+    (AT.option AT.int)
+    "getAt - returns None for an empty array"
+    (Array.getAt ~index:0 [||])
     None ;
 
   AT.check
     (AT.array AT.int)
-    "set - can be partially applied to set an element"
-    (let setZero = Array.set ~value:0 in
+    "set - can set a value at an index"
+    (let numbers = [| 1; 2; 3 |] in
+     numbers.(0) <- 0 ;
+     numbers)
+    [| 0; 2; 3 |] ;
+
+  AT.check
+    (AT.array AT.int)
+    "setAt - can be partially applied to set an element"
+    (let setZero = Array.setAt ~value:0 in
      let numbers = [| 1; 2; 3 |] in
      setZero numbers ~index:2 ;
      setZero numbers ~index:1 ;
@@ -248,8 +272,8 @@ let t_Array () =
 
   AT.check
     (AT.array AT.string)
-    "set - can be partially applied to set an index"
-    (let setZerothElement = Array.set ~index:0 in
+    "setAt - can be partially applied to set an index"
+    (let setZerothElement = Array.setAt ~index:0 in
      let animals = [| "ant"; "bat"; "cat" |] in
      setZerothElement animals ~value:"antelope" ;
      animals)
@@ -568,7 +592,7 @@ let t_Array () =
     (let index = ref 0 in
      let calledValues = [| 0; 0; 0 |] in
      Array.forEach [| 1; 2; 3 |] ~f:(fun value ->
-         Array.set calledValues ~index:!index ~value ;
+         Array.setAt calledValues ~index:!index ~value ;
          index := !index + 1) ;
 
      calledValues)


### PR DESCRIPTION
As described in #72, rename `Array.get` to `Array.getAt`, `Array.set` to
`Array.setAt`, and introduce new APIs for `get` and `set` that work with
index operators so it's possible to write `array.(index) <- value` 
again.

Test plan: `make test`