### PR TITLE
Add the `Poly` module for `Map` and `Set`. 

### DIFF
--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -1258,29 +1258,36 @@ module Map = struct
 
   let get = Base.Map.find
 
-  let update m ~key ~f =
-    Base.Map.change m key ~f
+  let update m ~key ~f = Base.Map.change m key ~f
 
   let merge m1 m2 ~f =
     Base.Map.merge m1 m2 ~f:(fun ~key desc ->
-      match desc with
-      | `Left v1 -> f key (Some v1) None
-      | `Right v2 -> f key None (Some v2)
-      | `Both (v1, v2) -> f key (Some v1) (Some v2) )
+        match desc with
+        | `Left v1 ->
+            f key (Some v1) None
+        | `Right v2 ->
+            f key None (Some v2)
+        | `Both (v1, v2) ->
+            f key (Some v1) (Some v2))
+
 
   let map = Base.Map.map
 
   let filter = Base.Map.filter
 
-  let partition m ~f = Base.Map.partition_mapi m ~f:(fun ~key ~data ->
-    if (f ~key ~value:data) then `Fst data else `Snd data
-  )
+  let partition m ~f =
+    Base.Map.partition_mapi m ~f:(fun ~key ~data ->
+        if f ~key ~value:data then `Fst data else `Snd data)
 
-  let find m ~f = Base.Map.fold m ~init:None ~f:(fun ~key ~data matching ->
-    match matching with
-    | Some _ -> matching
-    | None -> if (f ~key ~value:data) then Some (key, data) else None
-  )
+
+  let find m ~f =
+    Base.Map.fold m ~init:None ~f:(fun ~key ~data matching ->
+        match matching with
+        | Some _ ->
+            matching
+        | None ->
+            if f ~key ~value:data then Some (key, data) else None)
+
 
   let any = Base.Map.exists
 
@@ -1290,9 +1297,10 @@ module Map = struct
 
   let for_each = forEach
 
-  let fold m ~initial ~f = Base.Map.fold m ~init:initial ~f:(fun ~key ~data acc ->
-    f acc ~key ~value:data
-  )
+  let fold m ~initial ~f =
+    Base.Map.fold m ~init:initial ~f:(fun ~key ~data acc ->
+        f acc ~key ~value:data)
+
 
   let keys = Base.Map.keys
 
@@ -1307,7 +1315,8 @@ module Map = struct
   let to_list = toList
 
   module Poly = struct
-    type nonrec ('k, 'v) t = ('k, 'v, Base.Comparator.Poly.comparator_witness) t
+    type nonrec ('k, 'v) t =
+      ('k, 'v, Base.Comparator.Poly.comparator_witness) t
 
     let empty = Base.Map.Poly.empty
 
@@ -1329,7 +1338,9 @@ module Map = struct
 
     let singleton ~key ~value = Base.Map.singleton (module Base.Int) key value
 
-    let fromList l = Base.Map.of_alist_reduce (module Base.Int) l ~f:(fun _ curr -> curr)
+    let fromList l =
+      Base.Map.of_alist_reduce (module Base.Int) l ~f:(fun _ curr -> curr)
+
 
     let from_list = fromList
 
@@ -1343,9 +1354,13 @@ module Map = struct
 
     let empty = Base.Map.empty (module Base.String)
 
-    let singleton ~key ~value = Base.Map.singleton (module Base.String) key value
+    let singleton ~key ~value =
+      Base.Map.singleton (module Base.String) key value
 
-    let fromList l = Base.Map.of_alist_reduce (module Base.String) l ~f:(fun _ curr -> curr)
+
+    let fromList l =
+      Base.Map.of_alist_reduce (module Base.String) l ~f:(fun _ curr -> curr)
+
 
     let from_list = fromList
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -2179,8 +2179,7 @@ module Set : sig
 
   (** Construct sets which can hold any data type using the polymorphic [compare] function *)
   module Poly : sig
-
-    type nonrec 'a t = ('a,  Base.Comparator.Poly.comparator_witness) t
+    type nonrec 'a t = ('a, Base.Comparator.Poly.comparator_witness) t
 
     val empty : 'a t
     (** The empty set *)
@@ -2207,7 +2206,6 @@ module Set : sig
 
   (** Construct sets of {!Int}s *)
   module Int : sig
-
     type nonrec t = (Int.t, Base.Int.comparator_witness) t
 
     val empty : t
@@ -2295,10 +2293,15 @@ module Map : sig
   val get : ('k, 'v, 'cmp) t -> 'k -> 'v option
   (** Get the value associated with a key. If the key is not present in the map, returns [None]. *)
 
-  val find : ('k, 'v, _) t -> f:(key:'k -> value:'v -> bool) -> ('k * 'v) option
+  val find :
+    ('k, 'v, _) t -> f:(key:'k -> value:'v -> bool) -> ('k * 'v) option
   (** Returns, as an {!Option} the first key-value pair for which [f] evaluates to true. If [f] doesn't return [true] for any of the elements [find] will return [None]. *)
 
-  val update : ('k, 'v, 'cmp) t -> key:'k -> f:('v option -> 'v option) -> ('k, 'v, 'cmp) t
+  val update :
+       ('k, 'v, 'cmp) t
+    -> key:'k
+    -> f:('v option -> 'v option)
+    -> ('k, 'v, 'cmp) t
   (** Update the value for a specific key using [f]. If [key] is not present in the map [f] will be called with [None]. *)
 
   val length : (_, _, _) t -> int
@@ -2321,10 +2324,10 @@ module Map : sig
   (** {1 Combine} *)
 
   val merge :
-    ('k, 'v1, 'cmp) t ->
-    ('k, 'v2, 'cmp) t ->
-    f:('k -> 'v1 option -> 'v2 option -> 'v3 option) ->
-    ('k, 'v3, 'cmp) t
+       ('k, 'v1, 'cmp) t
+    -> ('k, 'v2, 'cmp) t
+    -> f:('k -> 'v1 option -> 'v2 option -> 'v3 option)
+    -> ('k, 'v3, 'cmp) t
   (**
     Combine two maps. You provide a function [f] which is provided the key and the optional value from each map and needs to account for the three possibilities:
 
@@ -2343,10 +2346,14 @@ module Map : sig
   val filter : ('k, 'v, 'cmp) t -> f:('v -> bool) -> ('k, 'v, 'cmp) t
   (** Keep elements that [f] returns [true] for. *)
 
-  val partition : ('k, 'v, 'cmp) t -> f:(key:'k -> value:'v -> bool) -> ('k, 'v, 'cmp) t * ('k, 'v, 'cmp) t
+  val partition :
+       ('k, 'v, 'cmp) t
+    -> f:(key:'k -> value:'v -> bool)
+    -> ('k, 'v, 'cmp) t * ('k, 'v, 'cmp) t
   (** Divide a map into two, the first map will contain the key-value pairs that [f] returns [true] for, pairs that [f] returns [false] for will end up in the second. *)
 
-  val fold : ('k, 'v, _) t -> initial:'a -> f:('a -> key:'k -> value:'v -> 'a) -> 'a
+  val fold :
+    ('k, 'v, _) t -> initial:'a -> f:('a -> key:'k -> value:'v -> 'a) -> 'a
   (** Fold over the key-value pairs in a map. *)
 
   val forEach : (_, 'v, _) t -> f:('v -> unit) -> unit
@@ -2374,7 +2381,8 @@ module Map : sig
 
   (** Construct a Map which can be keyed by any data type using the polymorphic [compare] function. *)
   module Poly : sig
-    type nonrec ('key, 'value) t = ('key, 'value, Base.Comparator.Poly.comparator_witness) t
+    type nonrec ('key, 'value) t =
+      ('key, 'value, Base.Comparator.Poly.comparator_witness) t
 
     val empty : ('k, 'v) t
     (** A map with nothing in it. *)
@@ -2441,17 +2449,17 @@ module Map : sig
     val from_list : (string * 'value) list -> 'value t
   end
 
-(* module Regex : sig *)
-(*   type t *)
-(*  *)
-(*   type result *)
-(*  *)
-(*   val regex : string -> t *)
-(*  *)
-(*   val contains : re:t -> string -> bool *)
-(*  *)
-(*   val replace : re:t -> repl:string -> string -> string *)
-(*  *)
-(*   val matches : re:t -> string -> result option *)
-(* end *)
+  (* module Regex : sig *)
+  (*   type t *)
+  (*  *)
+  (*   type result *)
+  (*  *)
+  (*   val regex : string -> t *)
+  (*  *)
+  (*   val contains : re:t -> string -> bool *)
+  (*  *)
+  (*   val replace : re:t -> repl:string -> string -> string *)
+  (*  *)
+  (*   val matches : re:t -> string -> result option *)
+  (* end *)
 end


### PR DESCRIPTION
This PR adds polymorphic maps and sets as a new submodule to Map and Set.

In addition:
- The functions are documented
- Most functions in Set come with examples 
- IntDict and StringDict become the Int and String submodules of Map and IntSet and StringSet become the Int and String submodules of Set. I did this to be more consistent with both OCaml's and Javascript's terminology (both use 'Map' rather than 'Dict' / 'Dictionary')
- Expands the api provided by the *Dict and *Set modules to be comparable with the ones provided in Elms core.

This is just for the native side. If you approve of the API I will add the bs side and test suite.