### PR TITLE
Fix documentation build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ deps-bs:
 documentation:
 	@printf "\n\e[31mCompiling the documentation ...\e[0m\n"
 	opam exec -- dune build @doc
-	rm ./docs
+	rm -rf ./docs
 	ln -s _build/default/_doc/_html ./docs
 	@printf "\n\e[31mCompiled! The docs are now viewable at ./docs/index.html\e[0m\n"
 


### PR DESCRIPTION
Getting the following error when running `make documentation` for the first time since the `docs` directory has not been created before:

```
Compiling the documentation ...
opam exec -- dune build @doc
rm ./docs
rm: ./docs: No such file or directory
make: *** [documentation] Error 1
```

Switching to `rm -rf ./docs` should clear it up.