### PR TITLE
Remove deprecation warnings for string functions

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+bs/src/compat.ml

--- a/bs/bsconfig.json
+++ b/bs/bsconfig.json
@@ -4,7 +4,10 @@
   "sources": [
     {
       "dir" : "src",
-      "subdirs" : false
+      "subdirs" : false,
+      "public": [
+        "Tablecloth"
+      ]
     },
     {
       "dir": "__tests__",

--- a/bs/src/compat.ml
+++ b/bs/src/compat.ml
@@ -1,0 +1,30 @@
+(* This file is used to target different OCaml versions using the BuckleScript
+   preprocessor. This is a separate file since ocamlformat does not accept
+   the BuckleScript preprocessor. *)
+
+module String = struct
+#if OCAML_VERSION =~ ">=4.03" then
+
+  let toLower (s : string) : string = String.lowercase_ascii s
+
+  let toUpper (s : string) : string = String.uppercase_ascii s
+
+  let uncapitalize (s : string) : string = String.uncapitalize_ascii s
+
+  let capitalize (s : string) : string = String.capitalize_ascii s
+
+  let isCapitalized (s : string) : bool = s = String.capitalize_ascii s
+
+#else
+  let toLower (s : string) : string = String.lowercase s
+
+  let toUpper (s : string) : string = String.uppercase s
+
+  let uncapitalize (s : string) : string = String.uncapitalize s
+
+  let capitalize (s : string) : string = String.capitalize s
+
+  let isCapitalized (s : string) : bool = s = String.capitalize s
+
+#end
+end

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1205,19 +1205,19 @@ module String = struct
 
   let starts_with = startsWith
 
-  let toLower (s : string) : string = String.lowercase s
+  let toLower (s : string) : string = String.lowercase_ascii s
 
   let to_lower = toLower
 
-  let toUpper (s : string) : string = String.uppercase s
+  let toUpper (s : string) : string = String.uppercase_ascii s
 
   let to_upper = toUpper
 
-  let uncapitalize (s : string) : string = String.uncapitalize s
+  let uncapitalize (s : string) : string = String.uncapitalize_ascii s
 
-  let capitalize (s : string) : string = String.capitalize s
+  let capitalize (s : string) : string = String.capitalize_ascii s
 
-  let isCapitalized (s : string) : bool = s = String.capitalize s
+  let isCapitalized (s : string) : bool = s = String.capitalize_ascii s
 
   let is_capitalized = isCapitalized
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1205,32 +1205,7 @@ module String = struct
 
   let starts_with = startsWith
 
-  (* Silence warnings in BS 6: https://github.com/darklang/tablecloth/pull/88 *)
-#if OCAML_VERSION =~ ">=4.03" then
-
-  let toLower (s : string) : string = String.lowercase_ascii s
-
-  let toUpper (s : string) : string = String.uppercase_ascii s
-
-  let uncapitalize (s : string) : string = String.uncapitalize_ascii s
-
-  let capitalize (s : string) : string = String.capitalize_ascii s
-
-  let isCapitalized (s : string) : bool = s = String.capitalize_ascii s
-
-#else
-
-  let toLower (s : string) : string = String.lowercase s
-
-  let toUpper (s : string) : string = String.uppercase s
-
-  let uncapitalize (s : string) : string = String.uncapitalize s
-
-  let capitalize (s : string) : string = String.capitalize s
-
-  let isCapitalized (s : string) : bool = s = String.capitalize s
-
-#end
+  include Compat.String
 
   let to_lower = toLower
 

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -1205,19 +1205,36 @@ module String = struct
 
   let starts_with = startsWith
 
+  (* Silence warnings in BS 6: https://github.com/darklang/tablecloth/pull/88 *)
+#if OCAML_VERSION =~ ">=4.03" then
+
   let toLower (s : string) : string = String.lowercase_ascii s
 
-  let to_lower = toLower
-
   let toUpper (s : string) : string = String.uppercase_ascii s
-
-  let to_upper = toUpper
 
   let uncapitalize (s : string) : string = String.uncapitalize_ascii s
 
   let capitalize (s : string) : string = String.capitalize_ascii s
 
   let isCapitalized (s : string) : bool = s = String.capitalize_ascii s
+
+#else
+
+  let toLower (s : string) : string = String.lowercase s
+
+  let toUpper (s : string) : string = String.uppercase s
+
+  let uncapitalize (s : string) : string = String.uncapitalize s
+
+  let capitalize (s : string) : string = String.capitalize s
+
+  let isCapitalized (s : string) : bool = s = String.capitalize s
+
+#end
+
+  let to_lower = toLower
+
+  let to_upper = toUpper
 
   let is_capitalized = isCapitalized
 


### PR DESCRIPTION
I am getting warnings like this with bsb 6.0.1:
```ocaml
  1218 ┆ let capitalize (s : string) : string = String.capitalize s
  1219 ┆
  1220 ┆ let isCapitalized (s : string) : bool = s = String.capitalize s
  1221 ┆
  1222 ┆ let is_capitalized = isCapitalized

  deprecated: String.capitalize
Use String.capitalize_ascii instead.
```
This removes the warnings.