### PR TITLE
Make Result.map consistent with other maps

### DIFF
--- a/bs/__tests__/tablecloth_test.ml
+++ b/bs/__tests__/tablecloth_test.ml
@@ -10,7 +10,12 @@ let () =
               |> toEqual (Belt.Result.Error "error message")) ;
           test "maps Some into Ok" (fun () ->
               expect Result.(fromOption ~error:"error message" (Some 10))
-              |> toEqual (Belt.Result.Ok 10)))) ;
+              |> toEqual (Belt.Result.Ok 10))) ;
+      describe "map" (fun () ->
+          test "maps value on success" (fun () ->
+              expect Result.(map ~f:String.reverse (succeed "blah"))
+              |> toEqual (Belt.Result.Ok "halb")))) ;
+
   describe "Fun" (fun () ->
       test "identity" (fun () -> expect (Fun.identity 1) |> toEqual 1) ;
       test "ignore" (fun () -> expect (Fun.ignore 1) |> toEqual ()) ;

--- a/bs/src/tablecloth.ml
+++ b/bs/src/tablecloth.ml
@@ -569,7 +569,7 @@ module Result = struct
     List.foldRight ~f:(map2 ~f:(fun a b -> a :: b)) ~initial:(Ok []) l
 
 
-  let map (f : 'ok -> 'value) (r : ('err, 'ok) t) : ('err, 'value) t =
+  let map ~(f : 'ok -> 'value) (r : ('err, 'ok) t) : ('err, 'value) t =
     Belt.Result.map r f
 
 

--- a/bs/src/tablecloth.mli
+++ b/bs/src/tablecloth.mli
@@ -985,7 +985,7 @@ module Result : sig
     ]}
   *)
 
-  val map : ('ok -> 'value) -> ('err, 'ok) t -> ('err, 'value) t
+  val map : f:('ok -> 'value) -> ('err, 'ok) t -> ('err, 'value) t
   (**
     [Result.map f r] applies a function [f], which
     takes a non-[Result] argument and returns a non-[Result] value, to

--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -733,7 +733,7 @@ module Result = struct
     List.foldRight ~f:(map2 ~f:(fun a b -> a :: b)) ~initial:(Ok []) l
 
 
-  let map (f : 'ok -> 'value) (r : ('err, 'ok) t) : ('err, 'value) t =
+  let map ~(f : 'ok -> 'value) (r : ('err, 'ok) t) : ('err, 'value) t =
     Base.Result.map r ~f
 
 

--- a/native/src/tablecloth.mli
+++ b/native/src/tablecloth.mli
@@ -682,7 +682,7 @@ module Result : sig
 
   val combine : ('x, 'a) t list -> ('x, 'a list) t
 
-  val map : ('ok -> 'value) -> ('err, 'ok) t -> ('err, 'value) t
+  val map : f:('ok -> 'value) -> ('err, 'ok) t -> ('err, 'value) t
 
   val fromOption : error:'err -> 'ok option -> ('err, 'ok) t
 


### PR DESCRIPTION
Adds the `f:` label to `Result.map` in order to make it work either subject-first or subject-last. Fixes #114.