### PR TITLE
Don't use int_of_string_opt, which wasn't available before OCaml 4.05

### DIFF
--- a/native/src/tablecloth.ml
+++ b/native/src/tablecloth.ml
@@ -1103,7 +1103,7 @@ module Int = struct
 
   let to_string = toString
 
-  let fromString = int_of_string_opt
+  let fromString str = try Some (int_of_string str) with _ -> None
 
   let from_string = fromString
 end


### PR DESCRIPTION
The release of the native version of 0.0.7 failed due to a int_of_string_opt being missing in OCaml 4.04. This is a workaround.

https://ci.ocaml.org/ocaml/opam-repository/pr/16395?test=3%20Compilers