### PR TITLE
Add String.split failing test

### DIFF
--- a/bucklescript/test/StringTest.re
+++ b/bucklescript/test/StringTest.re
@@ -98,6 +98,20 @@ let suite =
     test("reverse", () => {
       expect(String.reverse("stressed")) |> toEqual(Eq.string, "desserts")
     });
+    describe("split", () => {
+      test("middle", () => {
+        expect(String.split("abc", ~on="b"))
+        |> toEqual(Eq.(list(string)), ["a", "c"])
+      });
+      test("start", () => {
+        expect(String.split("ab", ~on="a"))
+        |> toEqual(Eq.(list(string)), ["", "b"])
+      });
+      test("end", () => {
+        expect(String.split("ab", ~on="b"))
+        |> toEqual(Eq.(list(string)), ["a", ""])
+      });
+    });
 
     test("toArray", () => {
       expect(String.toArray("Standard"))

--- a/native/src/TableclothString.ml
+++ b/native/src/TableclothString.ml
@@ -58,7 +58,9 @@ let dropRight (s : string) ~(count : int) =
 
 let drop_right = dropRight
 
-let split t ~(on : string) = (Str.split (Str.regexp_string on) t : string list)
+let split t ~(on : string) =
+  (Str.split_delim (Str.regexp_string on) t : string list)
+
 
 let startsWith t ~prefix = Base.String.is_prefix ~prefix t
 


### PR DESCRIPTION
I run in to this issue in Dark I think.

`String.split` in some edge cases produces different result in `native` and in `bs` implementations.

`make test-bs` -> OK
`make test-native` -> KO

```
ASSERT split - start
[failure] Error split - start: expecting
[; b], got
[b].
Raised at file "stdlib.ml", line 29, characters 17-33
```

In Dark

<img width="444" alt="Screenshot 2020-05-27 at 22 57 13" src="https://user-images.githubusercontent.com/12428/83139943-8064bb80-a0ed-11ea-8ace-db5f70f17079.png">
<img width="603" alt="Screenshot 2020-05-27 at 22 57 25" src="https://user-images.githubusercontent.com/12428/83139959-878bc980-a0ed-11ea-9a46-ee540288c49a.png">

I found the relevant bit in ocaml docs:
https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html#VALsplit

There is `Str.split` and `Str.split_delim`. The second one behaves in the similar manner to JavaScript split used by `bs`. I am not 100% sure which behaviour you want but it should be the same in both implementation. If you want me to change `bs` implementation instead let me know.