### PR TITLE
orElse for TableclothResult

### DIFF
--- a/bucklescript/src/TableclothResult.ml
+++ b/bucklescript/src/TableclothResult.ml
@@ -36,6 +36,10 @@ let flatten a = match a with Ok a' -> a' | Error error -> Error error
 
 let or_ a b = match a with Ok _ -> a | _ -> b
 
+let orElse ta tb = match isError tb with true -> ta | false -> tb
+
+let or_else = orElse
+
 let and_ a b = match a with Ok _ -> b | _ -> a
 
 let unwrap t ~default = Belt.Result.getWithDefault t default

--- a/bucklescript/src/TableclothResult.ml
+++ b/bucklescript/src/TableclothResult.ml
@@ -38,8 +38,6 @@ let or_ a b = match a with Ok _ -> a | _ -> b
 
 let orElse ta tb = match isError tb with true -> ta | false -> tb
 
-let or_else = orElse
-
 let and_ a b = match a with Ok _ -> b | _ -> a
 
 let unwrap t ~default = Belt.Result.getWithDefault t default

--- a/bucklescript/src/TableclothResult.mli
+++ b/bucklescript/src/TableclothResult.mli
@@ -178,6 +178,21 @@ val or_ : ('ok, 'error) t -> ('ok, 'error) t -> ('ok, 'error) t
   {[Result.or_ (Error (`UnexpectedInvertabrate "Periwinkle")) (Error (`UnexpectedBird "Robin")) = (Error (`UnexpectedBird "Robin"))]}
 *)
 
+val orElse : ('ok, 'error) t -> ('ok 'error) t -> ('ok 'error) t
+
+(** Return the first argument if it {isError} otherwise return second
+   
+   {2 Examples}
+
+   Ok "the value I want"
+        |> Result.orElse (Ok "a default value")
+        = Ok “the value I want”
+
+   Error "Snakes!"
+        |> Result.orElse (Ok "a default value")
+        = Ok "a default value"
+*)
+
 val both : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t
 (** Combine two results, if both are [Ok] returns an [Ok] containing a {!Tuple} of the values.
 

--- a/bucklescript/src/TableclothResult.mli
+++ b/bucklescript/src/TableclothResult.mli
@@ -178,19 +178,15 @@ val or_ : ('ok, 'error) t -> ('ok, 'error) t -> ('ok, 'error) t
   {[Result.or_ (Error (`UnexpectedInvertabrate "Periwinkle")) (Error (`UnexpectedBird "Robin")) = (Error (`UnexpectedBird "Robin"))]}
 *)
 
-val orElse : ('ok, 'error) t -> ('ok 'error) t -> ('ok 'error) t
+val orElse : ('ok, 'error) t -> ('ok, 'error) t -> ('ok, 'error) t
 
 (** Return the first argument if it {isError} otherwise return second
    
    {2 Examples}
 
-   Ok "the value I want"
-        |> Result.orElse (Ok "a default value")
-        = Ok “the value I want”
+   {[(Ok "the value I want") |> Result.orElse (Ok "a default value") = (Ok “the value I want”)]}
 
-   Error "Snakes!"
-        |> Result.orElse (Ok "a default value")
-        = Ok "a default value"
+   {[(Error "Snakes!") |> Result.orElse (Ok "a default value")= Ok ("a default value")]}
 *)
 
 val both : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t

--- a/bucklescript/src/TableclothResult.mli
+++ b/bucklescript/src/TableclothResult.mli
@@ -180,13 +180,13 @@ val or_ : ('ok, 'error) t -> ('ok, 'error) t -> ('ok, 'error) t
 
 val orElse : ('ok, 'error) t -> ('ok, 'error) t -> ('ok, 'error) t
 
-(** Return the first argument if it {isError} otherwise return second
+(** Return the second argument if the first one is {!isError}, otherwise return the first
    
    {2 Examples}
 
    {[(Ok "the value I want") |> Result.orElse (Ok "a default value") = (Ok “the value I want”)]}
 
-   {[(Error "Snakes!") |> Result.orElse (Ok "a default value")= Ok ("a default value")]}
+   {[(Error "Snakes!") |> Result.orElse (Ok "a default value") = Ok ("a default value")]}
 *)
 
 val both : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t

--- a/bucklescript/test/ResultTest.re
+++ b/bucklescript/test/ResultTest.re
@@ -3,17 +3,29 @@ open AlcoJest;
 
 let suite =
   suite("Result", () => {
-    Result.(
-      describe("fromOption", () => {
-        test("maps None into Error", () => {
-          expect(fromOption(~error="error message", None))
-          |> toEqual(Eq.(result(int, string)), Error("error message"))
-        });
+    open Result;
+    describe("fromOption", () => {
+      test("maps None into Error", () => {
+        expect(fromOption(~error="error message", None))
+        |> toEqual(Eq.(result(int, string)), Error("error message"))
+      });
 
-        test("maps Some into Ok", () => {
-          expect(fromOption(~error="error message", Some(10)))
-          |> toEqual(Eq.(result(int, string)), Ok(10))
-        });
-      })
-    )
+      test("maps Some into Ok", () => {
+        expect(fromOption(~error="error message", Some(10)))
+        |> toEqual(Eq.(result(int, string)), Ok(10))
+      });
+    });
+
+    describe("orElse", () => {
+      test("if first is Ok then choose the first value", () => {
+        expect(orElse(Ok("This is Ok"), Ok("This is default")))
+        |> toEqual(Eq.(result(string, string)), Ok("This is Ok"))
+      });
+
+      test("if the first is an Error then choose the second value aka default value", () => {
+        expect(orElse(Error("This is an Error"), Ok("This is default")))
+        |> toEqual(Eq.(result(string,string)), Ok("This is default"))
+      });
+    });
+
   });

--- a/bucklescript/test/ResultTest.re
+++ b/bucklescript/test/ResultTest.re
@@ -18,15 +18,14 @@ let suite =
     });
 
     describe("orElse", () => {
-      test("the first value is the default and if second value is an Ok we get the second value", () => {
+      test("returns second value if Ok", () => {
         expect(orElse(Ok("This is default"), Ok("This is Ok")))
         |> toEqual(Eq.(result(string, string)), Ok("This is Ok"))
       });
 
-      test("if the second is an Error then choose the default value", () => {
+      test("returns the first value if an Error", () => {
         expect(orElse(Ok("This is default"), Error("This is an Error")))
-        |> toEqual(Eq.(result(string,string)), Ok("This is default"))
+        |> toEqual(Eq.(result(string, string)), Ok("This is default"))
       });
     });
-
   });

--- a/bucklescript/test/ResultTest.re
+++ b/bucklescript/test/ResultTest.re
@@ -4,6 +4,7 @@ open AlcoJest;
 let suite =
   suite("Result", () => {
     open Result;
+
     describe("fromOption", () => {
       test("maps None into Error", () => {
         expect(fromOption(~error="error message", None))
@@ -17,13 +18,13 @@ let suite =
     });
 
     describe("orElse", () => {
-      test("if first is Ok then choose the first value", () => {
-        expect(orElse(Ok("This is Ok"), Ok("This is default")))
+      test("the first value is the default and if second value is an Ok we get the second value", () => {
+        expect(orElse(Ok("This is default"), Ok("This is Ok")))
         |> toEqual(Eq.(result(string, string)), Ok("This is Ok"))
       });
 
-      test("if the first is an Error then choose the second value aka default value", () => {
-        expect(orElse(Error("This is an Error"), Ok("This is default")))
+      test("if the second is an Error then choose the default value", () => {
+        expect(orElse(Ok("This is default"), Error("This is an Error")))
         |> toEqual(Eq.(result(string,string)), Ok("This is default"))
       });
     });

--- a/native/src/TableclothResult.ml
+++ b/native/src/TableclothResult.ml
@@ -34,8 +34,6 @@ let or_ a b = match a with Ok _ -> a | _ -> b
 
 let orElse ta tb = match isError tb with true -> ta | false -> tb
 
-let or_else = orElse
-
 let and_ a b = match a with Ok _ -> b | _ -> a
 
 let unwrap = Result.value

--- a/native/src/TableclothResult.ml
+++ b/native/src/TableclothResult.ml
@@ -32,6 +32,10 @@ let flatten = Result.join
 
 let or_ a b = match a with Ok _ -> a | _ -> b
 
+let orElse ta tb = match isError tb with true -> ta | false -> tb
+
+let or_else = orElse
+
 let and_ a b = match a with Ok _ -> b | _ -> a
 
 let unwrap = Result.value


### PR DESCRIPTION
Refer #162 
Option already has an [`orElse`](https://github.com/darklang/tablecloth/blob/eca87dac1f2c3742526b67983b9da8a23f4bf3ba/bucklescript/src/TableclothOption.ml)

This PR tries to replicate the same functionality for Result's `orElse`