### PR TITLE
Add build matrix for native on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
       - bucklescript-build-and-test
       - bucklescript-integration-test
       - native-build-and-test
+      - native-integration-test
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
-      TC_NATIVE_OCAML_SWITCH: "4.10"
-      TC_BASE_VERSION: v0.13.2
+      TC_NATIVE_OCAML_SWITCH: << parameters.ocaml-version >>
+      TC_BASE_VERSION: << parameters.base-version >>
     working_directory: ~/repo
     steps:
       - checkout:
@@ -127,7 +127,11 @@ workflows:
   build:
     jobs:
       - bucklescript-build-and-test
-      - native-build-and-test
+      - native-build-and-test:
+          matrix:
+            parameters:
+              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10", "4.11", "4.12"]
+              base-version: ["v0.10", "v0.11", "v0.12", "v0.13", "v0.14"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,31 +19,11 @@ jobs:
       - run: make build-bs
       - run: make test-bs
       - run: make doc-bs
+      - run: make integration-test-bs
       - save_cache:
           key: v1-bucklescript-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/repo/node_modules
-
-  bucklescript-integration-test:
-    docker:
-      - image: circleci/node:12
-    environment:
-      CI: true
-      NODE_ENV: test
-    working_directory: ~/repo
-    steps:
-      - checkout:
-          path: ~/repo
-      - restore_cache:
-          keys:
-            - v1-bucklescript-integration-test-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - v1-bucklescript-integration-test-dependencies-{{ .Branch }}-
-            - v1-bucklescript-integration-test-dependencies-
-      - run: make integration-test-bs
-      - save_cache:
-          key: v1-bucklescript-integration-test-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths:
-            - ~/repo/integration-test/node_modules
 
   native-build-and-test:
     docker:
@@ -65,31 +45,9 @@ jobs:
       - run: make build-native
       - run: make test-native
       - run: make doc-native
-      - save_cache:
-          key: v2-native-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
-          paths:
-            - ~/.opam
-
-  native-integration-test:
-    docker:
-      - image: ocaml/opam2
-    environment:
-      CI: true
-    working_directory: ~/repo
-    steps:
-      - checkout:
-          path: ~/repo
-      - restore_cache:
-          keys:
-            - v2-native-integration-test-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
-            - v2-native-integration-test-dependencies-{{ .Branch }}-
-            - v2-native-integration-test-dependencies-
-      # m4 is a system dependency required by conf-m4 -> ocamlfind -> fmt -> alcotest
-      - run: sudo apt-get install -y m4
-      - run: make deps-native
       - run: make integration-test-native
       - save_cache:
-          key: v2-native-integration-test-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
+          key: v2-native-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
           paths:
             - ~/.opam
 
@@ -167,9 +125,7 @@ workflows:
   build:
     jobs:
       - bucklescript-build-and-test
-      - bucklescript-integration-test
       - native-build-and-test
-      - native-integration-test
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
+      NATIVE_OCAML_SWITCH: 4.10
+      BASE_VERSION: v0.13.2
     working_directory: ~/repo
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,20 +133,21 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
+              # Contributions welcome for commente out versions, see README
               ocaml-version:
-                 # - "4.06" # contributions welcome
-                 # - "4.07" # contributions welcome
+                 #- "4.06"
+                 #- "4.07"
                  - "4.08"
                  - "4.09"
-                 # - "4.10" # separate config below
+                 #- "4.10" # separate config below
                  #- "4.11" # no ocaml/opam2 version for this, probably works
               base-version:
-                 #- "v0.9.4" # contributions welcome
-                 #- "v0.10.0" # contributions welcome
-                 #- "v0.11.1" # contributions welcome
+                 #- "v0.9.4"
+                 #- "v0.10.0"
+                 #- "v0.11.1"
                  - "v0.12.2"
                  - "v0.13.2"
-                 #- "v0.14.0" # contributions welcome
+                 #- "v0.14.0"
       # Base 12 does not support OCaml 4.10
       - native-build-and-test:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
-      NATIVE_OCAML_SWITCH: 4.10
-      BASE_VERSION: v0.13.2
+      TC_NATIVE_OCAML_SWITCH: "4.10"
+      TC_BASE_VERSION: v0.13.2
     working_directory: ~/repo
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,9 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
-              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10", "4.11", "4.12"]
-              base-version: ["v0.10", "v0.11", "v0.12", "v0.13", "v0.14"]
+              # the ocaml/opam2 only supports to 4.10 atm
+              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10"]
+              base-version: ["v0.9.4", "v0.10.0", "v0.11.1", "v0.12.2", "v0.13.2", "v0.14.0"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             - ~/repo/node_modules
 
   native-build-and-test:
+    parameters:
+      ocaml-version: { type: string }
+      base-version: { type: string }
     docker:
       - image: ocaml/opam2
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,26 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
-              # the ocaml/opam2 only supports to 4.10 atm
-              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10"]
-              base-version: ["v0.9.4", "v0.10.0", "v0.11.1", "v0.12.2", "v0.13.2", "v0.14.0"]
+              ocaml-version:
+                 # - "4.06" # contributions welcome
+                 # - "4.07" # contributions welcome
+                 - "4.08"
+                 - "4.09"
+                 - "4.10"
+                 #- "4.11" # no ocaml/opam2 version for this, probably works
+              base-version:
+                 #- "v0.9.4" # contributions welcome
+                 #- "v0.10.0" # contributions welcome
+                 #- "v0.11.1" # contributions welcome
+                 - "v0.12.2"
+                 - "v0.13.2"
+                 #- "v0.14.0" # contributions welcome
+      # Base 12 does not support OCaml 4.10
+      - native-build-and-test:
+          matrix:
+            parameters:
+              ocaml-version: ["4.10"]
+              base-version: ["v0.13.2"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
                  # - "4.07" # contributions welcome
                  - "4.08"
                  - "4.09"
-                 - "4.10"
+                 # - "4.10" # separate config below
                  #- "4.11" # no ocaml/opam2 version for this, probably works
               base-version:
                  #- "v0.9.4" # contributions welcome

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-ifndef $(NATIVE_OCAML_SWITCH)
-  NATIVE_OCAML_SWITCH := 4.10.0
+ifndef TC_NATIVE_OCAML_SWITCH
+	TC_NATIVE_OCAML_SWITCH := 4.10.0
 endif
 
-ifndef $(BASE_VERSION)
-  BASE_VERSION := v0.13.2
+ifndef TC_BASE_VERSION
+	TC_BASE_VERSION := v0.13.2
 endif
-
 
 build-native:
 	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
@@ -66,8 +65,8 @@ integration-test-native:
 deps-native:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
-	opam switch set ${NATIVE_OCAML_SWITCH}
-	opam install alcotest base.${BASE_VERSION} dune junit junit_alcotest odoc reason -y
+	opam switch set ${TC_NATIVE_OCAML_SWITCH}
+	opam install alcotest base.${TC_BASE_VERSION} dune junit junit_alcotest odoc reason -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-bs:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+ifndef $(NATIVE_OCAML_SWITCH)
+  NATIVE_OCAML_SWITCH := 4.10.0
+endif
+
+ifndef $(BASE_VERSION)
+  BASE_VERSION := v0.13.2
+endif
+
+
 build-native:
 	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
 	opam config exec -- dune build
@@ -57,7 +66,8 @@ integration-test-native:
 deps-native:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
-	opam install alcotest base dune junit junit_alcotest odoc reason -y
+	opam switch set ${NATIVE_OCAML_SWITCH}
+	opam install alcotest base.${BASE_VERSION} dune junit junit_alcotest odoc reason -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-bs:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then add to your dune file:
 
 ## Usage
 
-The recommended way to use Tablecloth is with a top-level open at the beginning of a file. 
+The recommended way to use Tablecloth is with a top-level open at the beginning of a file.
 
 This will ensure that all the built-in modules are replaced.
 
@@ -51,6 +51,23 @@ let () =
   |> List.filterMap ~f:Char.fromCode
   |> String.fromList
 ```
+
+## Supported versions
+
+Tablecloth for native OCaml/reason supports OCaml 4.08-4.10 and Base
+v0.12.2/v0.13.2. Other versions of OCaml require small tweaks to our build
+system and may be supported later. Other versions of base require small code
+changes and may be supported later. OCaml 4.11 is believed to work but is not
+officially supported as there is no docker container for it in CI.
+
+We does not currently support (contributions welcome!):
+
+- OCaml 4.06
+- OCaml 4.07
+- Base v0.9
+- Base v0.10
+- Base v0.11
+- Base v0.14
 
 ## Design of Tablecloth
 
@@ -105,9 +122,9 @@ We also have design goals that are not yet achieved in the current version:
 
 ## Contributing
 
-Tablecloth is an ideal library to contribute to, even if you're new to OCaml or Reason. 
+Tablecloth is an ideal library to contribute to, even if you're new to OCaml or Reason.
 
-The maintainers are warm and friendly, and the project abides by a [Code of Conduct](./CODE_OF_CONDUCT.md). 
+The maintainers are warm and friendly, and the project abides by a [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 There are many small tasks to be done - a small change to a single function can be extremely
 helpful.

--- a/tablecloth-native.opam
+++ b/tablecloth-native.opam
@@ -14,5 +14,5 @@ license: "MIT with some exceptions"
 homepage: "https://github.com/darklang/tablecloth"
 bug-reports: "https://github.com/darklang/tablecloth/issues"
 dev-repo: "git://github.com/darklang/tablecloth"
-depends: [ "ocaml" "dune" {build} "base" { >= "v0.10.0" } ]
+depends: [ "ocaml" {>= 4.08 & < 4.11 } "dune" {build} "base" { >= "v0.12.0" & < v0.14.0 } ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
It seems that the master branch works on native for OCaml 4.08, 4.09 and 4.10, using base v0.12 and v013. I couldn't test 4.11, and other versions of base did not work for reasons I didn't investigate.

It seems like this is a good starting point to document what we support and to start to support other versions.

Fixes half of https://github.com/darklang/tablecloth/issues/179