### PR TITLE
Build matrix for bucklescript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   bucklescript-build-and-test:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:14.11.0
     environment:
       CI: true
       NODE_ENV: test
@@ -105,7 +105,7 @@ jobs:
 
   website-build:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:14.11.0
     environment:
       CI: true
       NODE_ENV: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
       - bucklescript-build-and-test
       - bucklescript-integration-test
       - native-build-and-test
+      - native-integration-test
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,10 +137,12 @@ workflows:
             parameters:
               bucklescript-version:
                 - "8.2.0"
+                - "8.0.0"
                 - "7.3.2"
-                - "6.2.1"
-                - "5.2.1"
-                - "4.0.18"
+                - "7.0.0"
+                # Pre version 6 not supported
+                #- "5.2.1"
+                #- "4.0.18"
       - native-build-and-test:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
-      TC_NATIVE_OCAML_SWITCH: "4.10"
-      TC_BASE_VERSION: v0.13.2
+      TC_NATIVE_OCAML_SWITCH: << parameters.ocaml-version >>
+      TC_BASE_VERSION: << parameters.base-version >>
     working_directory: ~/repo
     steps:
       - checkout:
@@ -127,7 +127,11 @@ workflows:
   build:
     jobs:
       - bucklescript-build-and-test
-      - native-build-and-test
+      - native-build-and-test:
+          matrix:
+            parameters:
+              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10", "4.11", "4.12"]
+              base-version: ["v0.10", "v0.11", "v0.12", "v0.13", "v0.14"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,31 +19,11 @@ jobs:
       - run: make build-bs
       - run: make test-bs
       - run: make doc-bs
+      - run: make integration-test-bs
       - save_cache:
           key: v1-bucklescript-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/repo/node_modules
-
-  bucklescript-integration-test:
-    docker:
-      - image: circleci/node:12
-    environment:
-      CI: true
-      NODE_ENV: test
-    working_directory: ~/repo
-    steps:
-      - checkout:
-          path: ~/repo
-      - restore_cache:
-          keys:
-            - v1-bucklescript-integration-test-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - v1-bucklescript-integration-test-dependencies-{{ .Branch }}-
-            - v1-bucklescript-integration-test-dependencies-
-      - run: make integration-test-bs
-      - save_cache:
-          key: v1-bucklescript-integration-test-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths:
-            - ~/repo/integration-test/node_modules
 
   native-build-and-test:
     docker:
@@ -65,31 +45,9 @@ jobs:
       - run: make build-native
       - run: make test-native
       - run: make doc-native
-      - save_cache:
-          key: v2-native-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
-          paths:
-            - ~/.opam
-
-  native-integration-test:
-    docker:
-      - image: ocaml/opam2
-    environment:
-      CI: true
-    working_directory: ~/repo
-    steps:
-      - checkout:
-          path: ~/repo
-      - restore_cache:
-          keys:
-            - v2-native-integration-test-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
-            - v2-native-integration-test-dependencies-{{ .Branch }}-
-            - v2-native-integration-test-dependencies-
-      # m4 is a system dependency required by conf-m4 -> ocamlfind -> fmt -> alcotest
-      - run: sudo apt-get install -y m4
-      - run: make deps-native
       - run: make integration-test-native
       - save_cache:
-          key: v2-native-integration-test-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
+          key: v2-native-dependencies-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
           paths:
             - ~/.opam
 
@@ -167,9 +125,7 @@ workflows:
   build:
     jobs:
       - bucklescript-build-and-test
-      - bucklescript-integration-test
       - native-build-and-test
-      - native-integration-test
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
+      NATIVE_OCAML_SWITCH: 4.10
+      BASE_VERSION: v0.13.2
     working_directory: ~/repo
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,20 +133,21 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
+              # Contributions welcome for commente out versions, see README
               ocaml-version:
-                 # - "4.06" # contributions welcome
-                 # - "4.07" # contributions welcome
+                 #- "4.06"
+                 #- "4.07"
                  - "4.08"
                  - "4.09"
-                 # - "4.10" # separate config below
+                 #- "4.10" # separate config below
                  #- "4.11" # no ocaml/opam2 version for this, probably works
               base-version:
-                 #- "v0.9.4" # contributions welcome
-                 #- "v0.10.0" # contributions welcome
-                 #- "v0.11.1" # contributions welcome
+                 #- "v0.9.4"
+                 #- "v0.10.0"
+                 #- "v0.11.1"
                  - "v0.12.2"
                  - "v0.13.2"
-                 #- "v0.14.0" # contributions welcome
+                 #- "v0.14.0"
       # Base 12 does not support OCaml 4.10
       - native-build-and-test:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - image: ocaml/opam2
     environment:
       CI: true
-      NATIVE_OCAML_SWITCH: 4.10
-      BASE_VERSION: v0.13.2
+      TC_NATIVE_OCAML_SWITCH: "4.10"
+      TC_BASE_VERSION: v0.13.2
     working_directory: ~/repo
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,6 @@ workflows:
                 - "7.1.1"
                 - "7.0.1"
                 # Pre version 6 not supported
-                #- "5.2.1"
-                #- "4.0.18"
       - native-build-and-test:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,9 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
-              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10", "4.11", "4.12"]
-              base-version: ["v0.10", "v0.11", "v0.12", "v0.13", "v0.14"]
+              # the ocaml/opam2 only supports to 4.10 atm
+              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10"]
+              base-version: ["v0.9.4", "v0.10.0", "v0.11.1", "v0.12.2", "v0.13.2", "v0.14.0"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             - ~/repo/node_modules
 
   native-build-and-test:
+    parameters:
+      ocaml-version: { type: string }
+      base-version: { type: string }
     docker:
       - image: ocaml/opam2
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,12 @@ workflows:
             parameters:
               bucklescript-version:
                 - "8.2.0"
-                - "8.0.0"
+                - "8.1.1"
+                - "8.0.3"
                 - "7.3.2"
-                - "7.0.0"
+                - "7.2.2"
+                - "7.1.1"
+                - "7.0.1"
                 # Pre version 6 not supported
                 #- "5.2.1"
                 #- "4.0.18"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,26 @@ workflows:
       - native-build-and-test:
           matrix:
             parameters:
-              # the ocaml/opam2 only supports to 4.10 atm
-              ocaml-version: ["4.06", "4.07", "4.08", "4.09", "4.10"]
-              base-version: ["v0.9.4", "v0.10.0", "v0.11.1", "v0.12.2", "v0.13.2", "v0.14.0"]
+              ocaml-version:
+                 # - "4.06" # contributions welcome
+                 # - "4.07" # contributions welcome
+                 - "4.08"
+                 - "4.09"
+                 - "4.10"
+                 #- "4.11" # no ocaml/opam2 version for this, probably works
+              base-version:
+                 #- "v0.9.4" # contributions welcome
+                 #- "v0.10.0" # contributions welcome
+                 #- "v0.11.1" # contributions welcome
+                 - "v0.12.2"
+                 - "v0.13.2"
+                 #- "v0.14.0" # contributions welcome
+      # Base 12 does not support OCaml 4.10
+      - native-build-and-test:
+          matrix:
+            parameters:
+              ocaml-version: ["4.10"]
+              base-version: ["v0.13.2"]
       - source-code-formatting
       - documentation-generator-build
       - website-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
                  # - "4.07" # contributions welcome
                  - "4.08"
                  - "4.09"
-                 - "4.10"
+                 # - "4.10" # separate config below
                  #- "4.11" # no ocaml/opam2 version for this, probably works
               base-version:
                  #- "v0.9.4" # contributions welcome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 version: 2.1
 jobs:
   bucklescript-build-and-test:
+    parameters:
+      bucklescript-version: { type: string }
     docker:
       - image: cimg/node:14.11.0
     environment:
       CI: true
       NODE_ENV: test
+      TC_BUCKLESCRIPT_VERSION: << parameters.bucklescript-version >>
     working_directory: ~/repo
     steps:
       - checkout:
@@ -129,7 +132,15 @@ workflows:
   version: 2
   build:
     jobs:
-      - bucklescript-build-and-test
+      - bucklescript-build-and-test:
+          matrix:
+            parameters:
+              bucklescript-version:
+                - "8.2.0"
+                - "7.3.2"
+                - "6.2.1"
+                - "5.2.1"
+                - "4.0.18"
       - native-build-and-test:
           matrix:
             parameters:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ ifndef TC_BASE_VERSION
 	TC_BASE_VERSION := v0.13.2
 endif
 
+
+ifndef TC_BUCKLESCRIPT_VERSION
+	TC_BUCKLESCRIPT_VERSION := 7.2.2
+endif
+
 build-native:
 	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
 	opam config exec -- dune build
@@ -71,6 +76,7 @@ deps-native:
 
 deps-bs:
 	@printf "\n\e[31mInstalling bs dependencies ...\e[0m\n"
+	npm install --only=dev bs-platform@${TC_BUCKLESCRIPT_VERSION}
 	npm install
 	@printf "\n\e[31mInstalled!\e[0m\n"
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 
 ifndef TC_BUCKLESCRIPT_VERSION
-	TC_BUCKLESCRIPT_VERSION := 7.2.2
+	TC_BUCKLESCRIPT_VERSION := 8.2.0
 endif
 
 build-native:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-ifndef $(NATIVE_OCAML_SWITCH)
-  NATIVE_OCAML_SWITCH := 4.10.0
+ifndef TC_NATIVE_OCAML_SWITCH
+	TC_NATIVE_OCAML_SWITCH := 4.10.0
 endif
 
-ifndef $(BASE_VERSION)
-  BASE_VERSION := v0.13.2
+ifndef TC_BASE_VERSION
+	TC_BASE_VERSION := v0.13.2
 endif
-
 
 build-native:
 	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
@@ -66,8 +65,8 @@ integration-test-native:
 deps-native:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
-	opam switch set ${NATIVE_OCAML_SWITCH}
-	opam install alcotest base.${BASE_VERSION} dune junit junit_alcotest odoc reason -y
+	opam switch set ${TC_NATIVE_OCAML_SWITCH}
+	opam install alcotest base.${TC_BASE_VERSION} dune junit junit_alcotest odoc reason -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-bs:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+ifndef $(NATIVE_OCAML_SWITCH)
+  NATIVE_OCAML_SWITCH := 4.10.0
+endif
+
+ifndef $(BASE_VERSION)
+  BASE_VERSION := v0.13.2
+endif
+
+
 build-native:
 	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
 	opam config exec -- dune build
@@ -57,7 +66,8 @@ integration-test-native:
 deps-native:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
-	opam install alcotest base dune junit junit_alcotest odoc reason -y
+	opam switch set ${NATIVE_OCAML_SWITCH}
+	opam install alcotest base.${BASE_VERSION} dune junit junit_alcotest odoc reason -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-bs:

--- a/README.md
+++ b/README.md
@@ -54,20 +54,28 @@ let () =
 
 ## Supported versions
 
-Tablecloth for native OCaml/reason supports OCaml 4.08-4.10 and Base
-v0.12.2/v0.13.2. Other versions of OCaml require small tweaks to our build
-system and may be supported later. Other versions of base require small code
-changes and may be supported later. OCaml 4.11 is believed to work but is not
-officially supported as there is no docker container for it in CI.
+### Bucklescript/ReasonML/Rescript
 
-We does not currently support (contributions welcome!):
+Tablecloth for Rescript supports bs-platform 7 and 8. Older versions of Tablecloth supported older versions of bs-platform.
 
-- OCaml 4.06
-- OCaml 4.07
-- Base v0.9
-- Base v0.10
-- Base v0.11
-- Base v0.14
+### Native
+
+Tablecloth for native OCaml/Reason supports OCaml 4.08-4.10 and Base
+v0.12.2/v0.13.2. We are open to supporting other versions:
+
+- OCaml 4.11 is believed to work but is not officially supported as there is no
+  docker container for it in CI.
+- OCaml 4.06 and 4.07 require small tweaks to our build system
+- Base v0.9, v0.10, and v0.11 require small code changes
+- Base v0.14 require small dependency tweaks
+
+### Development
+
+When developing Tablecloth, you can test it against different versions of
+bs-platform, OCaml (native) and Base, using the following commands:
+
+- `TC_BUCKLESCRIPT_VERSION=6.1.1 make deps-bs`
+- `TC_BASE_VERSION=v0.14.0 TC_NATIVE_OCAML_SWITCH=4.11.0 make deps-native`
 
 ## Design of Tablecloth
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then add to your dune file:
 
 ## Usage
 
-The recommended way to use Tablecloth is with a top-level open at the beginning of a file. 
+The recommended way to use Tablecloth is with a top-level open at the beginning of a file.
 
 This will ensure that all the built-in modules are replaced.
 
@@ -51,6 +51,23 @@ let () =
   |> List.filterMap ~f:Char.fromCode
   |> String.fromList
 ```
+
+## Supported versions
+
+Tablecloth for native OCaml/reason supports OCaml 4.08-4.10 and Base
+v0.12.2/v0.13.2. Other versions of OCaml require small tweaks to our build
+system and may be supported later. Other versions of base require small code
+changes and may be supported later. OCaml 4.11 is believed to work but is not
+officially supported as there is no docker container for it in CI.
+
+We does not currently support (contributions welcome!):
+
+- OCaml 4.06
+- OCaml 4.07
+- Base v0.9
+- Base v0.10
+- Base v0.11
+- Base v0.14
 
 ## Design of Tablecloth
 
@@ -105,9 +122,9 @@ We also have design goals that are not yet achieved in the current version:
 
 ## Contributing
 
-Tablecloth is an ideal library to contribute to, even if you're new to OCaml or Reason. 
+Tablecloth is an ideal library to contribute to, even if you're new to OCaml or Reason.
 
-The maintainers are warm and friendly, and the project abides by a [Code of Conduct](./CODE_OF_CONDUCT.md). 
+The maintainers are warm and friendly, and the project abides by a [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 There are many small tasks to be done - a small change to a single function can be extremely
 helpful.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ a handful of useful, supported commands:
 - `make test`: Run the test suite. You may need to `make build` first.
 - `make documentation`: Build the documentation to browse offline.
 - `make check-format`: Check your code is formatted correctly.
+- `make format`: Format code.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ a handful of useful, supported commands:
 - `make build`: Build the project.
 - `make test`: Run the test suite. You may need to `make build` first.
 - `make documentation`: Build the documentation to browse offline.
+- `make check-format`: Check your code is formatted correctly.
 
 ## License
 

--- a/bucklescript/src/TableclothInt.ml
+++ b/bucklescript/src/TableclothInt.ml
@@ -42,9 +42,17 @@ let ( / ) = ( / )
 
 let ( /. ) n by = Js.Int.toFloat n /. Js.Int.toFloat by
 
-let power ~base ~exponent = Js.Math.pow_int ~base ~exp:exponent
+let power ~base ~exponent =
+  let result = Js.Math.pow_float ~base:(Js.Int.toFloat base) ~exp:(Js.Int.toFloat exponent) in
+  let result =
+  if result > TableclothFloat.maximumSafeInteger
+  then TableclothFloat.maximumSafeInteger
+  else if result < TableclothFloat.minimumSafeInteger
+  then TableclothFloat.minimumSafeInteger
+  else result
+  in Js.Math.unsafe_trunc result
 
-let ( ** ) base exponent = Js.Math.pow_int ~base ~exp:exponent
+let ( ** ) base exponent = power ~base ~exponent
 
 let negate = ( ~- )
 

--- a/bucklescript/src/TableclothInt.ml
+++ b/bucklescript/src/TableclothInt.ml
@@ -43,14 +43,18 @@ let ( / ) = ( / )
 let ( /. ) n by = Js.Int.toFloat n /. Js.Int.toFloat by
 
 let power ~base ~exponent =
-  let result = Js.Math.pow_float ~base:(Js.Int.toFloat base) ~exp:(Js.Int.toFloat exponent) in
   let result =
-  if result > TableclothFloat.maximumSafeInteger
-  then TableclothFloat.maximumSafeInteger
-  else if result < TableclothFloat.minimumSafeInteger
-  then TableclothFloat.minimumSafeInteger
-  else result
-  in Js.Math.unsafe_trunc result
+    Js.Math.pow_float ~base:(Js.Int.toFloat base) ~exp:(Js.Int.toFloat exponent)
+  in
+  let result =
+    if result > TableclothFloat.maximumSafeInteger
+    then TableclothFloat.maximumSafeInteger
+    else if result < TableclothFloat.minimumSafeInteger
+    then TableclothFloat.minimumSafeInteger
+    else result
+  in
+  Js.Math.unsafe_trunc result
+
 
 let ( ** ) base exponent = power ~base ~exponent
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "0.5.1",
-    "bs-platform": "7.2.2"
+    "bs-platform": ">=7.0.1"
   },
   "dependencies": {},
   "scripts": {

--- a/tablecloth-native.opam
+++ b/tablecloth-native.opam
@@ -14,5 +14,5 @@ license: "MIT with some exceptions"
 homepage: "https://github.com/darklang/tablecloth"
 bug-reports: "https://github.com/darklang/tablecloth/issues"
 dev-repo: "git://github.com/darklang/tablecloth"
-depends: [ "ocaml" "dune" {build} "base" { >= "v0.10.0" } ]
+depends: [ "ocaml" {>= 4.08 & < 4.11 } "dune" {build} "base" { >= "v0.12.0" & < v0.14.0 } ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/tablecloth-native.opam
+++ b/tablecloth-native.opam
@@ -14,5 +14,5 @@ license: "MIT with some exceptions"
 homepage: "https://github.com/darklang/tablecloth"
 bug-reports: "https://github.com/darklang/tablecloth/issues"
 dev-repo: "git://github.com/darklang/tablecloth"
-depends: [ "ocaml" {>= 4.08 & < 4.11 } "dune" {build} "base" { >= "v0.12.0" & < v0.14.0 } ]
+depends: [ "ocaml" {>= "4.08" & < "4.11" } "dune" {build} "base" { >= "v0.12.0" & < "v0.14.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This enables, documents, and tests in CI the versions we support for bucklescript, which is 7 and 8.

- 6 has problems because the Belt and OCaml result types aren't unified. It doesn't seem saveable in the same codebase and was supported by older versions so maybe no big deal.
- 4 and 5 don't support the current syntax we use. Doesn't seem worth it.

This fully solves https://github.com/darklang/tablecloth/issues/179, and is built on top of #181.